### PR TITLE
Wrap server broadcast message prefixes in []

### DIFF
--- a/src/game/client/hud_basechat.cpp
+++ b/src/game/client/hud_basechat.cpp
@@ -21,7 +21,9 @@ void CBaseHudChat::PrintSystemMsg(const char* const pszPrefixStr, const char* co
 
 	m_pChatHistory->InsertColorChange(bAdminMsg ? adminColour : m_clrText);
 
+	m_pChatHistory->InsertChar(L'[');
 	m_pChatHistory->InsertText(pszPrefixStr);
+	m_pChatHistory->InsertChar(L']');
 	m_pChatHistory->InsertText(L": ");
 
 	m_pChatHistory->InsertFade(flMessageShowDuration, flMessageFadeDuration);


### PR DESCRIPTION
This was added to differentiate server messages from player messages a bit more