### PR TITLE
Pylon: Force IPv4 for server post requests

### DIFF
--- a/src/networksystem/pylon.cpp
+++ b/src/networksystem/pylon.cpp
@@ -192,7 +192,7 @@ bool CPylon::PostServerHost(string& outMessage, string& outToken, string& outHos
     rapidjson::Document responseJson;
     CURLINFO status;
 
-    if (!SendRequest("/servers/add", requestJson, responseJson, outMessage, status, "server host error"))
+    if (!SendRequest("/servers/add", requestJson, responseJson, outMessage, status, "server host error", true, true))
     {
         return false;
     }
@@ -472,7 +472,7 @@ bool CPylon::GetEULA(MSEulaData_t& outData, string& outMessage) const
 //-----------------------------------------------------------------------------
 bool CPylon::SendRequest(const char* endpoint, const rapidjson::Document& requestJson,
     rapidjson::Document& responseJson, string& outMessage, CURLINFO& status,
-    const char* errorText, const bool checkEula) const
+    const char* errorText, const bool checkEula, const bool forceIPv4) const
 {
     if (!IsDedicated() && !IsEULAUpToDate() && checkEula)
     {
@@ -484,7 +484,7 @@ bool CPylon::SendRequest(const char* endpoint, const rapidjson::Document& reques
     JSON_DocumentToBufferDeserialize(requestJson, stringBuffer);
 
     string responseBody;
-    if (!QueryServer(endpoint, stringBuffer.GetString(), responseBody, outMessage, status))
+    if (!QueryServer(endpoint, stringBuffer.GetString(), responseBody, outMessage, status, forceIPv4))
     {
         return false;
     }
@@ -542,7 +542,7 @@ bool CPylon::SendRequest(const char* endpoint, const rapidjson::Document& reques
 // Output : True on success, false on failure.
 //-----------------------------------------------------------------------------
 bool CPylon::QueryServer(const char* endpoint, const char* request,
-    string& outResponse, string& outMessage, CURLINFO& outStatus) const
+    string& outResponse, string& outMessage, CURLINFO& outStatus, const bool forceIPv4) const
 {
     const bool showDebug = pylon_showdebuginfo.GetBool();
     const char* hostName = pylon_matchmaking_hostname.GetString();
@@ -563,6 +563,7 @@ bool CPylon::QueryServer(const char* endpoint, const char* request,
     params.timeout = curl_timeout.GetInt();
     params.verifyPeer = ssl_verify_peer.GetBool();
     params.verbose = curl_debug.GetBool();
+    params.forceIPv4 = forceIPv4;
 
     curl_slist* sList = nullptr;
     CURL* curl = CURLInitRequest(finalUrl.c_str(), request, outResponse, sList, params);

--- a/src/networksystem/pylon.h
+++ b/src/networksystem/pylon.h
@@ -49,8 +49,8 @@ private:
 	void ExtractError(const string& response, string& outMessage, CURLINFO status, const char* messageText = nullptr) const;
 
 	void LogBody(const rapidjson::Document& responseJson) const;
-	bool SendRequest(const char* endpoint, const rapidjson::Document& requestJson, rapidjson::Document& responseJson, string& outMessage, CURLINFO& status, const char* errorText = nullptr, const bool checkEula = true) const;
-	bool QueryServer(const char* endpoint, const char* request, string& outResponse, string& outMessage, CURLINFO& outStatus) const;
+	bool SendRequest(const char* endpoint, const rapidjson::Document& requestJson, rapidjson::Document& responseJson, string& outMessage, CURLINFO& status, const char* errorText = nullptr, const bool checkEula = true, const bool forceIPv4 = false) const;
+	bool QueryServer(const char* endpoint, const char* request, string& outResponse, string& outMessage, CURLINFO& outStatus, const bool forceIPv4 = false) const;
 
 	void SetDisabledMessage(string& outMsg) const;
 

--- a/src/public/tier2/curlutils.h
+++ b/src/public/tier2/curlutils.h
@@ -27,6 +27,7 @@ struct CURLParams
 		, followRedirect(false)
 		, verbose(false)
 		, failOnError(false)
+		, forceIPv4(false)
 	{}
 
 	void* readFunction;
@@ -38,6 +39,7 @@ struct CURLParams
 	bool followRedirect;
 	bool verbose;
 	bool failOnError;
+	bool forceIPv4;
 };
 
 size_t CURLReadFileCallback(void* data, const size_t size, const size_t nmemb, FILE* stream);

--- a/src/tier2/curlutils.cpp
+++ b/src/tier2/curlutils.cpp
@@ -42,6 +42,9 @@ void CURLInitCommonOptions(CURL* curl, const char* remote,
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, params.writeFunction);
     curl_easy_setopt(curl, CURLOPT_READFUNCTION, params.readFunction);
 
+    if (params.forceIPv4)
+        curl_easy_setopt(curl, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
+
     if (params.statusFunction)
     {
         Assert(progressData);


### PR DESCRIPTION
Curl likes to default to using IPv6 when its available and broadcasting over IPv6 is not supported.