### PR TITLE
Implement automatic JWT public key fetching

### DIFF
--- a/src/common/global.h
+++ b/src/common/global.h
@@ -85,6 +85,8 @@ extern ConVar* sv_voiceEcho;
 extern ConVar* sv_voiceenable;
 extern ConVar* sv_alltalk;
 
+extern ConVar sv_onlineAuthEnable;
+
 extern ConVar* sv_clampPlayerFrameTime;
 
 extern ConVar* playerframetimekick_margin;

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -65,18 +65,6 @@ CClientExtended* CClient::GetClientExtended(void) const
 }
 #endif // !CLIENT_DLL
 
-
-static const char JWT_PUBLIC_KEY[] = 
-"-----BEGIN PUBLIC KEY-----\n"
-"MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2/335exIZ6LE8pYi6e50\n"
-"7tH19tXaeeEJVF5XXpTCXpndXIIWVimvg6xQ381eajySDw93wvG1DzW3U/6LHzyt\n"
-"Q++N8w7N+FwnXyoDUD5Y8hheTZv6jjLoYT8ZtsMl20k9UosrbFBTMUhgmIT2dVth\n"
-"LH+rT9ohpUNwQXHJvTOs9eY74GyfFw93+32LANBPZ8b+S8S3oZnKFVeCxRkYKsV0\n"
-"b34POHVBbXNw6Kt163gR5zaiCfJJtRto9AA7MV2t9pfy8CChs3uJ+Xn7QVHD5cqt\n"
-"Msg9MBac2Pvs2j+8wJ/igAVL5L81z3FXVt04id59TfPMUbYhRfY8pk7FB0MCigOH\n"
-"dwIDAQAB\n"
-"-----END PUBLIC KEY-----\n";
-
 static ConVar sv_onlineAuthEnable("sv_onlineAuthEnable", "1", FCVAR_RELEASE, "Enables the server-side online authentication system");
 
 static ConVar sv_onlineAuthValidateExpiry("sv_onlineAuthValidateExpiry", "1", FCVAR_RELEASE, "Validate the online authentication token 'expiry' claim");
@@ -87,6 +75,35 @@ static ConVar sv_onlineAuthIssuedAtTolerance("sv_onlineAuthIssuedAtTolerance", "
 
 static ConVar sv_quota_stringCmdsPerSecond("sv_quota_stringCmdsPerSecond", "32", FCVAR_RELEASE, "How many string commands per second clients are allowed to submit, 0 to disallow all string commands", true, 0.f, false, 0.f);
 
+// [rexx]: yeah yeah. stdlib bad etc.
+static std::string JWT_PUBLIC_KEY;
+static std::string JWT_PUBLIC_KEY_HASH;
+
+static std::mutex s_jwtPublicKeyMutex;
+
+void CClient::CheckMSForNewAuthKey()
+{
+	std::thread([]()
+		{
+			std::lock_guard<std::mutex> lock(s_jwtPublicKeyMutex);
+			MSAuthKeyData_t keyData;
+			std::string msg;
+			
+			if (g_MasterServer.GetAuthKey(keyData, msg))
+			{
+				if (JWT_PUBLIC_KEY.length() == 0 || JWT_PUBLIC_KEY_HASH != keyData.keyHash)
+				{
+					JWT_PUBLIC_KEY = keyData.keyData;
+					JWT_PUBLIC_KEY_HASH = keyData.keyHash;
+				}
+			}
+			else
+			{
+				Warning(eDLL_T::SERVER, "Failed to check for a new JWT auth key: %s\n", msg.c_str());
+			}
+		}
+	).detach();
+}
 //---------------------------------------------------------------------------------
 // Purpose: check whether this client is authorized to join this server
 // Input  : *playerName  - 
@@ -144,6 +161,8 @@ bool CClient::Authenticate(const char* const playerName, char* const reasonBuf, 
 	if (tokenLen < 0)
 		ERROR_AND_RETURN("Token stitching failed");
 
+	std::lock_guard<std::mutex> lock(s_jwtPublicKeyMutex);
+
 	struct l8w8jwt_decoding_params params;
 	l8w8jwt_decoding_params_init(&params);
 
@@ -152,7 +171,7 @@ bool CClient::Authenticate(const char* const playerName, char* const reasonBuf, 
 	params.jwt = (char*)fullToken;
 	params.jwt_length = tokenLen;
 
-	params.verification_key = (unsigned char*)JWT_PUBLIC_KEY;
+	params.verification_key = (unsigned char*)JWT_PUBLIC_KEY.c_str();
 	params.verification_key_length = sizeof(JWT_PUBLIC_KEY);
 
 	params.validate_exp = sv_onlineAuthValidateExpiry.GetBool();

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -85,7 +85,6 @@ void CClient::CheckMSForNewAuthKey()
 {
 	std::thread([]()
 		{
-			std::lock_guard<std::mutex> lock(s_jwtPublicKeyMutex);
 			MSAuthKeyData_t keyData;
 			std::string msg;
 			
@@ -95,6 +94,7 @@ void CClient::CheckMSForNewAuthKey()
 				// sent them in the response
 				if (keyData.keyNeedsUpdate && (JWT_PUBLIC_KEY.length() == 0 || JWT_PUBLIC_KEY_HASH != keyData.keyHash))
 				{
+					std::lock_guard<std::mutex> lock(s_jwtPublicKeyMutex);
 					JWT_PUBLIC_KEY = keyData.keyData;
 					JWT_PUBLIC_KEY_HASH = keyData.keyHash;
 				}

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -89,9 +89,11 @@ void CClient::CheckMSForNewAuthKey()
 			MSAuthKeyData_t keyData;
 			std::string msg;
 			
-			if (g_MasterServer.GetAuthKey(keyData, msg))
+			if (g_MasterServer.GetAuthKey(JWT_PUBLIC_KEY_HASH, keyData, msg))
 			{
-				if (JWT_PUBLIC_KEY.length() == 0 || JWT_PUBLIC_KEY_HASH != keyData.keyHash)
+				// If keyNeedsUpdate is false, there are no valid keyData or keyHash values, as the masterserver will not have
+				// sent them in the response
+				if (keyData.keyNeedsUpdate && (JWT_PUBLIC_KEY.length() == 0 || JWT_PUBLIC_KEY_HASH != keyData.keyHash))
 				{
 					JWT_PUBLIC_KEY = keyData.keyData;
 					JWT_PUBLIC_KEY_HASH = keyData.keyHash;
@@ -161,7 +163,6 @@ bool CClient::Authenticate(const char* const playerName, char* const reasonBuf, 
 	if (tokenLen < 0)
 		ERROR_AND_RETURN("Token stitching failed");
 
-	std::lock_guard<std::mutex> lock(s_jwtPublicKeyMutex);
 
 	struct l8w8jwt_decoding_params params;
 	l8w8jwt_decoding_params_init(&params);
@@ -171,6 +172,7 @@ bool CClient::Authenticate(const char* const playerName, char* const reasonBuf, 
 	params.jwt = (char*)fullToken;
 	params.jwt_length = tokenLen;
 
+	std::lock_guard<std::mutex> lock(s_jwtPublicKeyMutex);
 	params.verification_key = (unsigned char*)JWT_PUBLIC_KEY.c_str();
 	params.verification_key_length = sizeof(JWT_PUBLIC_KEY);
 

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -107,6 +107,7 @@ public:
 	void RegisterNetMsgs(CNetChan* chan);
 	bool SendNetMsgEx(CNetMessage* pMsg, bool bLocal, bool bForceReliable, bool bVoice);
 
+	static void CheckMSForNewAuthKey();
 	bool Authenticate(const char* const playerName, char* const reasonBuf, const size_t reasonBufLen);
 	bool Connect(const char* szName, CNetChan* pNetChan, bool bFakePlayer,
 		CUtlVector<NET_SetConVar::cvar_t>* conVars, char* szMessage, int nMessageSize);

--- a/src/engine/host_state.cpp
+++ b/src/engine/host_state.cpp
@@ -397,6 +397,7 @@ void CHostState::Think(void) const
 #ifdef DEDICATED
 	static CFastTimer pylonTimer;
 #endif // DEDICATED
+	static CFastTimer authTimer;
 
 	if (!bInitialized) // Initialize clocks.
 	{
@@ -405,6 +406,7 @@ void CHostState::Think(void) const
 #ifdef DEDICATED
 		pylonTimer.Start();
 #endif // DEDICATED
+		authTimer.Start();
 		bInitialized = true;
 	}
 
@@ -433,6 +435,13 @@ void CHostState::Think(void) const
 		pylonTimer.Start();
 	}
 #endif // DEDICATED
+
+	if (authTimer.GetDurationInProgress().GetSeconds() > pylon_auth_refresh_interval.GetFloat())
+	{
+		CClient::CheckMSForNewAuthKey();
+		authTimer.Start();
+	}
+
 #endif // !CLIENT_DLL
 }
 

--- a/src/engine/host_state.cpp
+++ b/src/engine/host_state.cpp
@@ -56,7 +56,6 @@
 #include "game/server/gameinterface.h"
 #endif // !CLIENT_DLL
 #include "game/shared/vscript_shared.h"
-
 #ifndef CLIENT_DLL
 static ConVar host_statusRefreshRate("host_statusRefreshRate", "0.5", FCVAR_RELEASE, "Host status refresh rate (seconds).", true, 0.f, false, 0.f);
 
@@ -407,6 +406,11 @@ void CHostState::Think(void) const
 		pylonTimer.Start();
 #endif // DEDICATED
 		authTimer.Start();
+
+		// Quick! Get a key before we get players!
+		if (sv_onlineAuthEnable.GetBool())
+			CClient::CheckMSForNewAuthKey();
+
 		bInitialized = true;
 	}
 
@@ -438,7 +442,10 @@ void CHostState::Think(void) const
 
 	if (authTimer.GetDurationInProgress().GetSeconds() > pylon_auth_refresh_interval.GetFloat())
 	{
-		CClient::CheckMSForNewAuthKey();
+		// Don't bother getting keys if we aren't even using online auth
+		if(sv_onlineAuthEnable.GetBool())
+			CClient::CheckMSForNewAuthKey();
+
 		authTimer.Start();
 	}
 

--- a/src/networksystem/pylon.cpp
+++ b/src/networksystem/pylon.cpp
@@ -18,7 +18,7 @@
 ConVar pylon_matchmaking_enabled("pylon_matchmaking_enabled", "1", FCVAR_RELEASE | FCVAR_ACCESSIBLE_FROM_THREADS, "Whether to use the Pylon matchmaking server");
 ConVar pylon_matchmaking_hostname("pylon_matchmaking_hostname", "r5r.org", FCVAR_RELEASE | FCVAR_ACCESSIBLE_FROM_THREADS, "Holds the Pylon matchmaking hostname");
 ConVar pylon_host_update_interval("pylon_host_update_interval", "5", FCVAR_RELEASE, "Time interval between status updates to the Pylon master server", true, 5.f, false, 0.f, "seconds");
-ConVar pylon_auth_refresh_interval("pylon_auth_refresh_interval", "30", FCVAR_RELEASE, "Time interval between requests to refresh the server's client authentication public key", true, 5.f, false, 0.f, "seconds");
+ConVar pylon_auth_refresh_interval("pylon_auth_refresh_interval", "30", FCVAR_RELEASE, "Time interval between requests to refresh the server's client authentication public key", true, 15.f, false, 0.f, "seconds");
 ConVar pylon_host_visibility("pylon_host_visibility", "0", FCVAR_RELEASE, "Determines the visibility to the Pylon master server", true, 0.f, true, 2.f, "0 = Offline, 1 = Hidden, 2 = Public");
 ConVar pylon_showdebuginfo("pylon_showdebuginfo", "0", FCVAR_RELEASE | FCVAR_ACCESSIBLE_FROM_THREADS, "Shows debug output for Pylon");
 

--- a/src/networksystem/pylon.cpp
+++ b/src/networksystem/pylon.cpp
@@ -18,7 +18,7 @@
 ConVar pylon_matchmaking_enabled("pylon_matchmaking_enabled", "1", FCVAR_RELEASE | FCVAR_ACCESSIBLE_FROM_THREADS, "Whether to use the Pylon matchmaking server");
 ConVar pylon_matchmaking_hostname("pylon_matchmaking_hostname", "r5r.org", FCVAR_RELEASE | FCVAR_ACCESSIBLE_FROM_THREADS, "Holds the Pylon matchmaking hostname");
 ConVar pylon_host_update_interval("pylon_host_update_interval", "5", FCVAR_RELEASE, "Time interval between status updates to the Pylon master server", true, 5.f, false, 0.f, "seconds");
-ConVar pylon_auth_refresh_interval("pylon_auth_refresh_interval", "30", FCVAR_RELEASE, "Time interval between requests to refresh the server's client authentication public key", true, 30.f, false, 0.f, "seconds");
+ConVar pylon_auth_refresh_interval("pylon_auth_refresh_interval", "30", FCVAR_RELEASE, "Time interval between requests to refresh the server's client authentication public key", true, 5.f, false, 0.f, "seconds");
 ConVar pylon_host_visibility("pylon_host_visibility", "0", FCVAR_RELEASE, "Determines the visibility to the Pylon master server", true, 0.f, true, 2.f, "0 = Offline, 1 = Hidden, 2 = Public");
 ConVar pylon_showdebuginfo("pylon_showdebuginfo", "0", FCVAR_RELEASE | FCVAR_ACCESSIBLE_FROM_THREADS, "Shows debug output for Pylon");
 
@@ -467,7 +467,7 @@ bool CPylon::GetEULA(MSEulaData_t& outData, string& outMessage) const
 //          &outMessage - 
 // Output : True on success, false on failure.
 //-----------------------------------------------------------------------------
-bool CPylon::GetAuthKey(MSAuthKeyData_t& outData, string& outMessage) const
+bool CPylon::GetAuthKey(const std::string& currentHash, MSAuthKeyData_t& outData, string& outMessage) const
 {
     if (!IsEnabled())
     {
@@ -478,6 +478,11 @@ bool CPylon::GetAuthKey(MSAuthKeyData_t& outData, string& outMessage) const
     rapidjson::Document requestJson;
     requestJson.SetObject();
 
+    rapidjson::Document::AllocatorType& allocator = requestJson.GetAllocator();
+
+    requestJson.AddMember("version", SDK_VERSION, allocator);
+    requestJson.AddMember("keyHash", rapidjson::Value(currentHash.c_str(), allocator), allocator);
+
     rapidjson::Document responseJson;
     CURLINFO status;
 
@@ -486,7 +491,10 @@ bool CPylon::GetAuthKey(MSAuthKeyData_t& outData, string& outMessage) const
         return false;
     }
 
-    rapidjson::Document::ConstMemberIterator keyInfoIt;
+    // If the response contains the key "requireUpdate" and it's set to false, there is no other data in the response.
+    // Otherwise, continue parsing to get the key data and hash
+    if (!JSON_GetValue(responseJson, "requireUpdate", outData.keyNeedsUpdate) && !outData.keyNeedsUpdate)
+        return true;
 
     std::string keyData;
     if (!JSON_GetValue(responseJson, "keyData", keyData))

--- a/src/networksystem/pylon.cpp
+++ b/src/networksystem/pylon.cpp
@@ -18,6 +18,7 @@
 ConVar pylon_matchmaking_enabled("pylon_matchmaking_enabled", "1", FCVAR_RELEASE | FCVAR_ACCESSIBLE_FROM_THREADS, "Whether to use the Pylon matchmaking server");
 ConVar pylon_matchmaking_hostname("pylon_matchmaking_hostname", "r5r.org", FCVAR_RELEASE | FCVAR_ACCESSIBLE_FROM_THREADS, "Holds the Pylon matchmaking hostname");
 ConVar pylon_host_update_interval("pylon_host_update_interval", "5", FCVAR_RELEASE, "Time interval between status updates to the Pylon master server", true, 5.f, false, 0.f, "seconds");
+ConVar pylon_auth_refresh_interval("pylon_auth_refresh_interval", "30", FCVAR_RELEASE, "Time interval between requests to refresh the server's client authentication public key", true, 30.f, false, 0.f, "seconds");
 ConVar pylon_host_visibility("pylon_host_visibility", "0", FCVAR_RELEASE, "Determines the visibility to the Pylon master server", true, 0.f, true, 2.f, "0 = Offline, 1 = Hidden, 2 = Public");
 ConVar pylon_showdebuginfo("pylon_showdebuginfo", "0", FCVAR_RELEASE | FCVAR_ACCESSIBLE_FROM_THREADS, "Shows debug output for Pylon");
 
@@ -454,6 +455,51 @@ bool CPylon::GetEULA(MSEulaData_t& outData, string& outMessage) const
         !JSON_GetValue(data, "contents", outData.contents))
     {
         outMessage = "schema is invalid";
+        return false;
+    }
+
+    return true;
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: Gets the current public auth key from master server.
+// Input  : &outData    -
+//          &outMessage - 
+// Output : True on success, false on failure.
+//-----------------------------------------------------------------------------
+bool CPylon::GetAuthKey(MSAuthKeyData_t& outData, string& outMessage) const
+{
+    if (!IsEnabled())
+    {
+        SetDisabledMessage(outMessage);
+        return false;
+    }
+
+    rapidjson::Document requestJson;
+    requestJson.SetObject();
+
+    rapidjson::Document responseJson;
+    CURLINFO status;
+
+    if (!SendRequest("/server/auth/keyinfo", requestJson, responseJson, outMessage, status, "auth key fetch error", false))
+    {
+        return false;
+    }
+
+    rapidjson::Document::ConstMemberIterator keyInfoIt;
+
+    std::string keyData;
+    if (!JSON_GetValue(responseJson, "keyData", keyData))
+    {
+        outMessage = "no keyData";
+        return false;
+    }
+
+    outData.keyData = Base64Decode(keyData);
+    
+    if (!JSON_GetValue(responseJson, "keyHash", outData.keyHash))
+    {
+        outMessage = "no keyHash";
         return false;
     }
 

--- a/src/networksystem/pylon.h
+++ b/src/networksystem/pylon.h
@@ -6,6 +6,7 @@
 
 extern ConVar pylon_matchmaking_hostname;
 extern ConVar pylon_host_update_interval;
+extern ConVar pylon_auth_refresh_interval;
 extern ConVar pylon_host_visibility;
 extern ConVar pylon_showdebuginfo;
 
@@ -14,6 +15,12 @@ struct MSEulaData_t
 	int version;
 	string language;
 	string contents;
+};
+
+struct MSAuthKeyData_t
+{
+	string keyData;
+	string keyHash;
 };
 
 class CPylon
@@ -31,6 +38,7 @@ public:
 	bool AuthForConnection(const uint64_t nucleusId, const char* ipAddress, const char* authCode, string& outToken, string& outMessage) const;
 
 	bool GetEULA(MSEulaData_t& outData, string& outMessage) const;
+	bool GetAuthKey(MSAuthKeyData_t& outData, string& outMessage) const;
 	bool IsEnabled() const;
 
 	inline void SetLanguage(const char* lang)

--- a/src/networksystem/pylon.h
+++ b/src/networksystem/pylon.h
@@ -21,6 +21,7 @@ struct MSAuthKeyData_t
 {
 	string keyData;
 	string keyHash;
+	bool keyNeedsUpdate;
 };
 
 class CPylon
@@ -38,7 +39,7 @@ public:
 	bool AuthForConnection(const uint64_t nucleusId, const char* ipAddress, const char* authCode, string& outToken, string& outMessage) const;
 
 	bool GetEULA(MSEulaData_t& outData, string& outMessage) const;
-	bool GetAuthKey(MSAuthKeyData_t& outData, string& outMessage) const;
+	bool GetAuthKey(const std::string& currentHash, MSAuthKeyData_t& outData, string& outMessage) const;
 	bool IsEnabled() const;
 
 	inline void SetLanguage(const char* lang)


### PR DESCRIPTION
This implements automatic requesting of the client authentication JWT public key from Pylon.
This allows the public key to be rerolled and put into immediate use without requiring a server update.

Currently, this does not include fetching the key on startup, however I am currently investigating where is best to add the function call.

(right repo this time!)