### PR TITLE
CImguiSystem improvements

### DIFF
--- a/src/gameui/imgui_surface.h
+++ b/src/gameui/imgui_surface.h
@@ -23,9 +23,10 @@ public:
 	virtual void SetStyleVar();
 	virtual void SetRect(const float width, const float height, const float x, const float y);
 
-	// inlines:
-	inline void ToggleActive() { m_activated ^= true; }
+	virtual void ToggleActive() { m_activated ^= true; }
+	virtual void SetActive(const bool active) { m_activated = active; }
 
+	// inlines:
 	inline bool IsActivated() const { return m_activated; }
 	inline bool IsVisible() const { return m_fadeAlpha > 0.0f; }
 

--- a/src/gameui/imgui_surface.h
+++ b/src/gameui/imgui_surface.h
@@ -7,6 +7,7 @@
 
 class CImguiSurface
 {
+	friend class CImguiSystem;
 public:
 	CImguiSurface();
 	virtual ~CImguiSurface() { };

--- a/src/gameui/imgui_system.cpp
+++ b/src/gameui/imgui_system.cpp
@@ -19,6 +19,7 @@
 CImguiSystem::CImguiSystem()
 	: m_enabled(false)
 	, m_initialized(false)
+	, m_isOccluded(false)
 	, m_hasActiveSurfacesThisFrame(false)
 	, m_hasNewFrame(false)
 	, m_repeatFrame(false)
@@ -279,6 +280,27 @@ void CImguiSystem::SampleFrame()
 	Assert(ThreadInMainThread(), "CImguiSystem::SampleFrame() should only be called from the main thread!");
 	Assert(IsInitialized());
 
+	UpdateOcclusionStatus();
+
+	if (m_isOccluded)
+	{
+		// At least update the activity flag as surfaces can still be disabled
+		// while the game window is occluded.
+		bool active = false;
+
+		FOR_EACH_VEC(m_surfaceList, i)
+		{
+			if ((m_surfaceList[i])->IsActivated())
+			{
+				active = true;
+				break;
+			}
+		}
+
+		m_hasActiveSurfacesThisFrame = active;
+		return;
+	}
+
 	ImGui_ImplDX11_NewFrame();
 
 	// See https://github.com/ocornut/imgui/issues/6895
@@ -322,6 +344,9 @@ void CImguiSystem::SwapBuffers()
 	Assert(ThreadInMainThread(), "CImguiSystem::SwapBuffers() should only be called from the main thread!");
 	Assert(IsInitialized());
 
+	if (m_isOccluded)
+		return;
+
 	ImDrawData* const drawData = ImGui::GetDrawData();
 	Assert(drawData);
 
@@ -357,6 +382,26 @@ void CImguiSystem::RenderFrame()
 bool CImguiSystem::IsSurfaceActive() const
 {
 	return m_hasActiveSurfacesThisFrame;
+}
+
+//-----------------------------------------------------------------------------
+// Checks whether our window has been occluded.
+//-----------------------------------------------------------------------------
+bool CImguiSystem::IsOccluded() const
+{
+	HWND window = g_pGame->GetWindow();
+	return IsIconic(window);
+}
+
+//-----------------------------------------------------------------------------
+// Updates the window occlusion state which is used to determine if we can
+// sample frames and swap them later on.
+//-----------------------------------------------------------------------------
+void CImguiSystem::UpdateOcclusionStatus()
+{
+	m_isOccluded = !IsInitialized()
+		? true
+		: IsOccluded();
 }
 
 //-----------------------------------------------------------------------------

--- a/src/gameui/imgui_system.cpp
+++ b/src/gameui/imgui_system.cpp
@@ -21,7 +21,7 @@ CImguiSystem::CImguiSystem()
 	: m_enabled(false)
 	, m_initialized(false)
 	, m_isOccluded(false)
-	, m_hasActiveSurfacesThisFrame(false)
+	, m_hasActiveSurfaceThisFrame(false)
 	, m_hasInputFocus(false)
 	, m_wantsMouseDuringLastClick(true)
 	, m_hasNewFrame(false)
@@ -314,7 +314,7 @@ void CImguiSystem::SampleFrame()
 			}
 		}
 
-		m_hasActiveSurfacesThisFrame = active;
+		m_hasActiveSurfaceThisFrame = active;
 		return;
 	}
 
@@ -367,8 +367,8 @@ void CImguiSystem::SampleFrame()
 		}
 	}
 
-	m_hasActiveSurfacesThisFrame = numActiveSurfaces > 0;
-	const bool shouldHaveInputFocus = m_hasActiveSurfacesThisFrame;
+	m_hasActiveSurfaceThisFrame = numActiveSurfaces > 0;
+	const bool shouldHaveInputFocus = m_hasActiveSurfaceThisFrame;
 
 	if (m_hasInputFocus != shouldHaveInputFocus)
 	{
@@ -432,7 +432,7 @@ void CImguiSystem::RenderFrame()
 //-----------------------------------------------------------------------------
 bool CImguiSystem::IsSurfaceActive() const
 {
-	return m_hasActiveSurfacesThisFrame;
+	return m_hasActiveSurfaceThisFrame;
 }
 
 //-----------------------------------------------------------------------------

--- a/src/gameui/imgui_system.cpp
+++ b/src/gameui/imgui_system.cpp
@@ -119,6 +119,9 @@ void CImguiSystem::SetupIO() const
 	ImGuiIO& io = ImGui::GetIO();
 	io.ConfigFlags |= ImGuiConfigFlags_IsSRGB;
 
+	io.IniFilename = "platform\\cfg\\user\\imgui.ini";
+	io.LogFilename = "platform\\logs\\imgui_log.txt";
+
 	SetupFonts();
 }
 

--- a/src/gameui/imgui_system.cpp
+++ b/src/gameui/imgui_system.cpp
@@ -279,8 +279,6 @@ void CImguiSystem::SampleFrame()
 	Assert(ThreadInMainThread(), "CImguiSystem::SampleFrame() should only be called from the main thread!");
 	Assert(IsInitialized());
 
-	AUTO_LOCK(m_inputEventQueueMutex);
-
 	ImGui_ImplDX11_NewFrame();
 
 	// See https://github.com/ocornut/imgui/issues/6895

--- a/src/gameui/imgui_system.cpp
+++ b/src/gameui/imgui_system.cpp
@@ -286,6 +286,8 @@ void CImguiSystem::SampleFrame()
 
 	ImGui::NewFrame();
 
+	ClampActiveWindowToScreenRect();
+
 	int numActiveSurfaces = 0;
 
 	FOR_EACH_VEC(m_surfaceList, i)
@@ -350,6 +352,29 @@ void CImguiSystem::RenderFrame()
 bool CImguiSystem::IsSurfaceActive() const
 {
 	return m_hasActiveSurfacesThisFrame;
+}
+
+//-----------------------------------------------------------------------------
+// Clamps the cursor to the rect of the game window
+//-----------------------------------------------------------------------------
+void CImguiSystem::ClampActiveWindowToScreenRect() const
+{
+	if (!ImGui::IsAnyItemActive() || !ImGui::IsMouseDragging(ImGuiMouseButton_Left))
+		return; // Not dragging anything.
+
+	RECT rect;
+	if (!GetClientRect(g_pGame->GetWindow(), &rect))
+		return;
+
+	POINT pt;
+	if (!GetCursorPos(&pt))
+		return;
+
+	if (!ScreenToClient(g_pGame->GetWindow(), &pt))
+		return;
+
+	if (pt.x < 0 || pt.y < 0 || pt.x >= rect.right || pt.y >= rect.bottom)
+		ImGui::ClearActiveID(); // Drop it here so we won't drag it outside our game window.
 }
 
 //-----------------------------------------------------------------------------

--- a/src/gameui/imgui_system.cpp
+++ b/src/gameui/imgui_system.cpp
@@ -282,9 +282,16 @@ void CImguiSystem::SampleFrame()
 	AUTO_LOCK(m_inputEventQueueMutex);
 
 	ImGui_ImplDX11_NewFrame();
-	ImGui_ImplWin32_NewFrame();
 
-	ImGui::NewFrame();
+	// See https://github.com/ocornut/imgui/issues/6895
+	// Only the following functions modify g.InputEventsQueue[],
+	// so we could get away with scoping the mutex.
+	{
+		AUTO_LOCK(m_inputEventQueueMutex);
+
+		ImGui_ImplWin32_NewFrame();
+		ImGui::NewFrame();
+	}
 
 	ClampActiveWindowToScreenRect();
 

--- a/src/gameui/imgui_system.cpp
+++ b/src/gameui/imgui_system.cpp
@@ -60,10 +60,21 @@ bool CImguiSystem::Init()
 
 	SetupIO();
 
-	if (!ImGui_ImplWin32_Init(g_pGame->GetWindow()) || 
-		!ImGui_ImplDX11_Init(D3D11Device(), D3D11DeviceContext()))
+	if (!ImGui_ImplWin32_Init(g_pGame->GetWindow()))
 	{
 		Assert(0);
+		ImGui::DestroyContext(context);
+
+		m_enabled = false;
+		return false;
+	}
+
+	if (!ImGui_ImplDX11_Init(D3D11Device(), D3D11DeviceContext()))
+	{
+		Assert(0);
+
+		ImGui_ImplWin32_Shutdown();
+		ImGui::DestroyContext(context);
 
 		m_enabled = false;
 		return false;

--- a/src/gameui/imgui_system.cpp
+++ b/src/gameui/imgui_system.cpp
@@ -19,9 +19,9 @@
 CImguiSystem::CImguiSystem()
 	: m_enabled(false)
 	, m_initialized(false)
+	, m_hasActiveSurfacesThisFrame(false)
 	, m_hasNewFrame(false)
 	, m_repeatFrame(false)
-	, m_activeSurfaces(0)
 {
 }
 
@@ -233,16 +233,6 @@ void CImguiSystem::LoadFont(const char* const fontPath, const bool mergeMode, co
 void CImguiSystem::AddSurface(CImguiSurface* const surface)
 {
 	Assert(IsInitialized());
-
-	const int numSurfaces = m_surfaceList.Count();
-	Assert(numSurfaces < IMGUI_SYSTEM_MAX_SURFACES);
-
-	if (numSurfaces == IMGUI_SYSTEM_MAX_SURFACES)
-	{
-		Error(eDLL_T::ENGINE, EXIT_FAILURE, "%s: out of room installing surface %p(\"%s\"); reached code limit of %d!\n",
-			__FUNCTION__, surface, surface->m_surfaceLabel, IMGUI_SYSTEM_MAX_SURFACES);
-	}
-
 	m_surfaceList.AddToTail(surface);
 }
 
@@ -255,10 +245,7 @@ void CImguiSystem::RemoveSurface(CImguiSurface* const surface)
 	const int idx = m_surfaceList.Find(surface);
 
 	if (idx != m_surfaceList.InvalidIndex())
-	{
 		m_surfaceList.Remove(idx);
-		MarkSurfaceActive(idx, false);
-	}
 	else
 		Assert(0);
 }
@@ -299,14 +286,18 @@ void CImguiSystem::SampleFrame()
 
 	ImGui::NewFrame();
 
+	int numActiveSurfaces = 0;
+
 	FOR_EACH_VEC(m_surfaceList, i)
 	{
 		CImguiSurface* const surface = m_surfaceList[i];
 		surface->RunFrame();
 
-		const bool active = surface->IsActivated();
-		MarkSurfaceActive(i, active);
+		if (surface->IsActivated())
+			numActiveSurfaces++;
 	}
+
+	m_hasActiveSurfacesThisFrame = numActiveSurfaces > 0;
 
 	ImGuiSystem_RenderNotifications();
 
@@ -358,15 +349,7 @@ void CImguiSystem::RenderFrame()
 //-----------------------------------------------------------------------------
 bool CImguiSystem::IsSurfaceActive() const
 {
-	return m_activeSurfaces & (IMGUI_SYSTEM_MAX_SURFACES-1);
-}
-
-//-----------------------------------------------------------------------------
-// Marks a specific surface as active.
-//-----------------------------------------------------------------------------
-void CImguiSystem::MarkSurfaceActive(const int idx, const bool active)
-{
-	m_activeSurfaces = (m_activeSurfaces & ~(1ull << idx)) | ((u64)active << idx);
+	return m_hasActiveSurfacesThisFrame;
 }
 
 //-----------------------------------------------------------------------------

--- a/src/gameui/imgui_system.cpp
+++ b/src/gameui/imgui_system.cpp
@@ -21,6 +21,7 @@ CImguiSystem::CImguiSystem()
 	, m_initialized(false)
 	, m_hasNewFrame(false)
 	, m_repeatFrame(false)
+	, m_activeSurfaces(0)
 {
 }
 
@@ -232,6 +233,15 @@ void CImguiSystem::LoadFont(const char* const fontPath, const bool mergeMode, co
 void CImguiSystem::AddSurface(CImguiSurface* const surface)
 {
 	Assert(IsInitialized());
+
+	const int numSurfaces = m_surfaceList.Count();
+
+	if (numSurfaces == IMGUI_SYSTEM_MAX_SURFACES)
+	{
+		Error(eDLL_T::ENGINE, EXIT_FAILURE, "%s: out of room installing surface %p(\"%s\"); reached code limit of %d!\n",
+			__FUNCTION__, surface, surface->m_surfaceLabel, IMGUI_SYSTEM_MAX_SURFACES);
+	}
+
 	m_surfaceList.AddToTail(surface);
 }
 
@@ -241,7 +251,15 @@ void CImguiSystem::AddSurface(CImguiSurface* const surface)
 void CImguiSystem::RemoveSurface(CImguiSurface* const surface)
 {
 	Assert(!IsInitialized());
-	m_surfaceList.FindAndRemove(surface);
+	const int idx = m_surfaceList.Find(surface);
+
+	if (idx != m_surfaceList.InvalidIndex())
+	{
+		m_surfaceList.Remove(idx);
+		MarkSurfaceActive(idx, false);
+	}
+	else
+		Assert(0);
 }
 
 inline void ImGuiSystem_RenderNotifications()
@@ -284,6 +302,9 @@ void CImguiSystem::SampleFrame()
 	{
 		CImguiSurface* const surface = m_surfaceList[i];
 		surface->RunFrame();
+
+		const bool active = surface->IsActivated();
+		MarkSurfaceActive(i, active);
 	}
 
 	ImGuiSystem_RenderNotifications();
@@ -336,13 +357,15 @@ void CImguiSystem::RenderFrame()
 //-----------------------------------------------------------------------------
 bool CImguiSystem::IsSurfaceActive() const
 {
-	FOR_EACH_VEC(m_surfaceList, i)
-	{
-		if (m_surfaceList[i]->IsActivated())
-			return true;
-	}
+	return m_activeSurfaces & (IMGUI_SYSTEM_MAX_SURFACES-1);
+}
 
-	return false;
+//-----------------------------------------------------------------------------
+// Marks a specific surface as active.
+//-----------------------------------------------------------------------------
+void CImguiSystem::MarkSurfaceActive(const int idx, const bool active)
+{
+	m_activeSurfaces = (m_activeSurfaces & ~(1ull << idx)) | ((u64)active << idx);
 }
 
 //-----------------------------------------------------------------------------

--- a/src/gameui/imgui_system.cpp
+++ b/src/gameui/imgui_system.cpp
@@ -10,6 +10,7 @@
 
 #include "tier1/keyvalues.h"
 #include "filesystem/filesystem.h"
+#include "inputsystem/inputsystem.h"
 #include "imgui_system.h"
 #include "imgui/misc/ImGuiNotify.hpp"
 
@@ -21,6 +22,8 @@ CImguiSystem::CImguiSystem()
 	, m_initialized(false)
 	, m_isOccluded(false)
 	, m_hasActiveSurfacesThisFrame(false)
+	, m_hasInputFocus(false)
+	, m_wantsMouseDuringLastClick(true)
 	, m_hasNewFrame(false)
 	, m_repeatFrame(false)
 {
@@ -329,6 +332,25 @@ void CImguiSystem::SampleFrame()
 
 	ClampActiveWindowToScreenRect();
 
+	const ImGuiIO& io = ImGui::GetIO(); // Check if we clicked outside any window.
+	bool closeAll = false;
+
+	if (ImGui::IsMouseClicked(ImGuiMouseButton_Left))
+	{
+		// Make sure that during the time we clicked, that this took
+		// place while Dear ImGui still wants input (this is needed
+		// to avoid events such as clicking on the imgui window, then
+		// dragging the cursor outside of it and releasing as that
+		// would close them too with the old logic of just checking
+		// io.WantCaptureMouse directly after the release event!
+		m_wantsMouseDuringLastClick = io.WantCaptureMouse;
+	}
+	else if (!m_wantsMouseDuringLastClick && ImGui::IsMouseReleased(ImGuiMouseButton_Left))
+	{
+		m_wantsMouseDuringLastClick = true;
+		closeAll = true;
+	}
+
 	int numActiveSurfaces = 0;
 
 	FOR_EACH_VEC(m_surfaceList, i)
@@ -337,10 +359,25 @@ void CImguiSystem::SampleFrame()
 		surface->RunFrame();
 
 		if (surface->IsActivated())
-			numActiveSurfaces++;
+		{
+			if (closeAll)
+				surface->SetActive(false);
+			else
+				numActiveSurfaces++;
+		}
 	}
 
 	m_hasActiveSurfacesThisFrame = numActiveSurfaces > 0;
+	const bool shouldHaveInputFocus = m_hasActiveSurfacesThisFrame;
+
+	if (m_hasInputFocus != shouldHaveInputFocus)
+	{
+		g_pInputSystem->EnableInput(!shouldHaveInputFocus);
+		m_hasInputFocus = shouldHaveInputFocus;
+
+		DevMsg(eDLL_T::ENGINE, "%s: input focus to imgui system has been %s\n",
+			__FUNCTION__, shouldHaveInputFocus ? "enabled" : "disabled");
+	}
 
 	ImGuiSystem_RenderNotifications();
 

--- a/src/gameui/imgui_system.cpp
+++ b/src/gameui/imgui_system.cpp
@@ -235,6 +235,7 @@ void CImguiSystem::AddSurface(CImguiSurface* const surface)
 	Assert(IsInitialized());
 
 	const int numSurfaces = m_surfaceList.Count();
+	Assert(numSurfaces < IMGUI_SYSTEM_MAX_SURFACES);
 
 	if (numSurfaces == IMGUI_SYSTEM_MAX_SURFACES)
 	{

--- a/src/gameui/imgui_system.h
+++ b/src/gameui/imgui_system.h
@@ -69,7 +69,7 @@ private:
 	bool m_enabled;
 	bool m_initialized;
 	bool m_isOccluded;
-	bool m_hasActiveSurfacesThisFrame;
+	bool m_hasActiveSurfaceThisFrame;
 
 	bool m_hasInputFocus;
 	bool m_wantsMouseDuringLastClick;

--- a/src/gameui/imgui_system.h
+++ b/src/gameui/imgui_system.h
@@ -71,6 +71,9 @@ private:
 	bool m_isOccluded;
 	bool m_hasActiveSurfacesThisFrame;
 
+	bool m_hasInputFocus;
+	bool m_wantsMouseDuringLastClick;
+
 	std::atomic_bool m_hasNewFrame;
 	std::atomic_bool m_repeatFrame;
 };

--- a/src/gameui/imgui_system.h
+++ b/src/gameui/imgui_system.h
@@ -8,6 +8,10 @@
 #include "imgui/misc/imgui_snapshot.h"
 #include "imgui_surface.h"
 
+// Max number of surfaces to be installed this is limited to the bit length of
+// CImguiSystem::m_activeSurfaces.
+#define IMGUI_SYSTEM_MAX_SURFACES 64
+
 // Max number of fonts to be loaded and merged.
 #define IMGUI_SYSTEM_MAX_FONTS 16
 
@@ -33,6 +37,7 @@ public:
 	void RenderFrame();
 
 	bool IsSurfaceActive() const;
+	void MarkSurfaceActive(const int idx, const bool active);
 
 	// statics:
 	static LRESULT MessageHandler(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
@@ -66,6 +71,8 @@ private:
 
 	std::atomic_bool m_hasNewFrame;
 	std::atomic_bool m_repeatFrame;
+
+	u64 m_activeSurfaces;
 };
 
 CImguiSystem* ImguiSystem();

--- a/src/gameui/imgui_system.h
+++ b/src/gameui/imgui_system.h
@@ -8,10 +8,6 @@
 #include "imgui/misc/imgui_snapshot.h"
 #include "imgui_surface.h"
 
-// Max number of surfaces to be installed this is limited to the bit length of
-// CImguiSystem::m_activeSurfaces.
-#define IMGUI_SYSTEM_MAX_SURFACES 64
-
 // Max number of fonts to be loaded and merged.
 #define IMGUI_SYSTEM_MAX_FONTS 16
 
@@ -37,7 +33,6 @@ public:
 	void RenderFrame();
 
 	bool IsSurfaceActive() const;
-	void MarkSurfaceActive(const int idx, const bool active);
 
 	// statics:
 	static LRESULT MessageHandler(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
@@ -68,11 +63,10 @@ private:
 
 	bool m_enabled;
 	bool m_initialized;
+	bool m_hasActiveSurfacesThisFrame;
 
 	std::atomic_bool m_hasNewFrame;
 	std::atomic_bool m_repeatFrame;
-
-	u64 m_activeSurfaces;
 };
 
 CImguiSystem* ImguiSystem();

--- a/src/gameui/imgui_system.h
+++ b/src/gameui/imgui_system.h
@@ -34,6 +34,9 @@ public:
 
 	bool IsSurfaceActive() const;
 
+	bool IsOccluded() const;
+	void UpdateOcclusionStatus();
+
 	void ClampActiveWindowToScreenRect() const;
 
 	// statics:
@@ -65,6 +68,7 @@ private:
 
 	bool m_enabled;
 	bool m_initialized;
+	bool m_isOccluded;
 	bool m_hasActiveSurfacesThisFrame;
 
 	std::atomic_bool m_hasNewFrame;

--- a/src/gameui/imgui_system.h
+++ b/src/gameui/imgui_system.h
@@ -34,6 +34,8 @@ public:
 
 	bool IsSurfaceActive() const;
 
+	void ClampActiveWindowToScreenRect() const;
+
 	// statics:
 	static LRESULT MessageHandler(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
 


### PR DESCRIPTION
- CImguiSystem::IsSurfaceActive() is now of constant time complexity
- Contention on CImguiSystem::m_inputEventQueueMutex has been significantly reduced
- Input will now be dropped immediately if the cursor leaves the game window rect to avoid panels getting stuck/invisible
- Imgui no longer renders if the game window is occluded
- Fixed a memory leak if Dear ImGui initialization failed
- Moved log and cfg files to designated directories to avoid polluting the root dir of the game
- All panels automatically hide if the user clicks on game area, this allows for switching back to game without manually closing