### PR TITLE
Rcon security hardening and bug fixes

### DIFF
--- a/src/common/igameserverdata.h
+++ b/src/common/igameserverdata.h
@@ -38,6 +38,10 @@ struct ConnectedNetConsoleData_s
 	bool validated;        // Revalidates netconsole if false.
 	bool authorized;       // Set to true after successful netconsole auth.
 	bool inputOnly;        // If set, don't send spew to this netconsole.
+	bool isServer;         // Whether this netcon is the server.
+	u64 nextSendSeqNr;     // The sequence number to be used for the next msg to send.
+	u64 lastRecvSeqNr;     // The last recv'd data sequence number from remote.
+	u64 sessionId;         // Unique session ID for this connection.
 	NetConFrameHeader_s frameHeader; // Current frame header.
 	vector<byte> recvBuffer;
 
@@ -51,6 +55,10 @@ struct ConnectedNetConsoleData_s
 		validated = false;
 		authorized = false;
 		inputOnly = true;
+		isServer = false;
+		nextSendSeqNr = 1;
+		lastRecvSeqNr = 0;
+		sessionId = 0;
 		frameHeader.magic = 0;
 		frameHeader.length = 0;
 	}

--- a/src/engine/client/cl_rcon.cpp
+++ b/src/engine/client/cl_rcon.cpp
@@ -34,8 +34,8 @@ static ConCommand rcon("rcon", RCON_CmdQuery_f, "Forward RCON message to remote 
 //-----------------------------------------------------------------------------
 // Purpose: 
 //-----------------------------------------------------------------------------
-CRConClient::CRConClient()
-	: m_bInitialized(false)
+CRConClient::CRConClient() : CNetConBase(false)
+	, m_bInitialized(false)
 {
 }
 
@@ -102,15 +102,14 @@ void CRConClient::Disconnect(const char* szReason)
 
 //-----------------------------------------------------------------------------
 // Purpose: processes received message
-// Input  : *pMsgBug - 
-//			nMsgLen - 
+// Input  : &data - 
 //			nMaxLen - 
 //-----------------------------------------------------------------------------
-bool CRConClient::ProcessMessage(const byte* const pMsgBuf, const u32 nMsgLen, const u32 nMaxLen)
+bool CRConClient::ProcessMessage(ConnectedNetConsoleData_s& data, const u32 nMaxLen)
 {
 	netcon::response response;
 
-	if (!NetconShared_UnpackEnvelope(this, pMsgBuf, nMsgLen, nMaxLen, &response, rcon_debug.GetBool()))
+	if (!NetconShared_UnpackEnvelope(this, data, nMaxLen, &response, rcon_encryptframes.GetBool(), rcon_debug.GetBool()))
 	{
 		Disconnect("received invalid message");
 		return false;
@@ -162,14 +161,20 @@ void CRConClient::RequestConsoleLog(const bool bWantLog)
 	// a listen server. Listen server's already log to the same console,
 	// sending logs will cause the print func to get called recursively forever.
 	Assert(!(bWantLog && IsRemoteLocal()));
+	ConnectedNetConsoleData_s* pData = GetData();
+
+	if (!pData)
+	{
+		Assert(0);
+		return;
+	}
 
 	const char* const szEnable = bWantLog ? "1" : "0";
-	const SocketHandle_t hSocket = GetSocket();
 
 	vector<byte> vecMsg;
-	const bool ret = Serialize(vecMsg, "", 0, szEnable, 1, netcon::request_e::SERVERDATA_REQUEST_SEND_CONSOLE_LOG);
+	const bool ret = Serialize(*pData, vecMsg, "", 0, szEnable, 1, netcon::request_e::SERVERDATA_REQUEST_SEND_CONSOLE_LOG);
 
-	if (ret && !Send(hSocket, vecMsg.data(), (u32)vecMsg.size()))
+	if (ret && !Send(pData->socket, vecMsg.data(), (u32)vecMsg.size()))
 	{
 		Error(eDLL_T::CLIENT, NO_ERROR, "Failed to send RCON message: (%s)\n", "SOCKET_ERROR");
 	}
@@ -177,17 +182,18 @@ void CRConClient::RequestConsoleLog(const bool bWantLog)
 
 //-----------------------------------------------------------------------------
 // Purpose: serializes input
-// Input  : *svReqBuf - 
+// Input  : &data - 
+//			*svReqBuf - 
 //			nReqMsgLen - 
 //			*svReqVal - 
 //			nReqValLen -
 //			request_t - 
 // Output : serialized results as string
 //-----------------------------------------------------------------------------
-bool CRConClient::Serialize(vector<byte>& vecBuf, const char* szReqBuf, const size_t nReqMsgLen,
+bool CRConClient::Serialize(ConnectedNetConsoleData_s& data, vector<byte>& vecBuf, const char* szReqBuf, const size_t nReqMsgLen,
 	const char* szReqVal, const size_t nReqValLen, const netcon::request_e requestType) const
 {
-	return NetconClient_Serialize(this, vecBuf, szReqBuf, nReqMsgLen, szReqVal, nReqValLen, requestType,
+	return NetconClient_Serialize(this, data, vecBuf, szReqBuf, nReqMsgLen, szReqVal, nReqValLen, requestType,
 		rcon_encryptframes.GetBool(), rcon_debug.GetBool());
 }
 
@@ -326,7 +332,13 @@ static void RCON_CmdQuery_f(const CCommand& args)
 		{
 			vector<byte> vecMsg;
 			bool bSuccess = false;
-			const SocketHandle_t hSocket = RCONClient()->GetSocket();
+			ConnectedNetConsoleData_s* pData = RCONClient()->GetData();
+
+			if (!pData)
+			{
+				Assert(0);
+				return;
+			}
 
 			if (strcmp(args.Arg(1), "PASS") == 0)
 			{
@@ -335,7 +347,7 @@ static void RCON_CmdQuery_f(const CCommand& args)
 					const char* const pass = args.Arg(2);
 					const size_t passLen = strlen(pass);
 
-					bSuccess = RCONClient()->Serialize(vecMsg, pass, passLen, "", 0, netcon::request_e::SERVERDATA_REQUEST_AUTH);
+					bSuccess = RCONClient()->Serialize(*pData, vecMsg, pass, passLen, "", 0, netcon::request_e::SERVERDATA_REQUEST_AUTH);
 				}
 				else // Need at least 3 arguments for a password in PASS command (rcon PASS <password>)
 				{
@@ -345,7 +357,7 @@ static void RCON_CmdQuery_f(const CCommand& args)
 
 				if (bSuccess)
 				{
-					RCONClient()->Send(hSocket, vecMsg.data(), (u32)vecMsg.size());
+					RCONClient()->Send(pData->socket, vecMsg.data(), (u32)vecMsg.size());
 				}
 
 				return;
@@ -362,10 +374,10 @@ static void RCON_CmdQuery_f(const CCommand& args)
 			const char* const value = args.ArgS();
 			const size_t valueLen = strlen(value);
 
-			bSuccess = RCONClient()->Serialize(vecMsg, request, requestLen, value, valueLen, netcon::request_e::SERVERDATA_REQUEST_EXECCOMMAND);
+			bSuccess = RCONClient()->Serialize(*pData, vecMsg, request, requestLen, value, valueLen, netcon::request_e::SERVERDATA_REQUEST_EXECCOMMAND);
 			if (bSuccess)
 			{
-				RCONClient()->Send(hSocket, vecMsg.data(), (u32)vecMsg.size());
+				RCONClient()->Send(pData->socket, vecMsg.data(), (u32)vecMsg.size());
 			}
 			return;
 		}

--- a/src/engine/client/cl_rcon.h
+++ b/src/engine/client/cl_rcon.h
@@ -15,9 +15,9 @@ public:
 	void RunFrame(void);
 
 	virtual void Disconnect(const char* szReason = nullptr) override;
-	virtual bool ProcessMessage(const byte* pMsgBuf, const u32 nMsgLen, const u32 nMaxLen) override;
+	virtual bool ProcessMessage(ConnectedNetConsoleData_s& data, const u32 nMaxLen) override;
 
-	bool Serialize(vector<byte>& vecBuf, const char* szReqBuf, const size_t nReqMsgLen,
+	bool Serialize(ConnectedNetConsoleData_s& data, vector<byte>& vecBuf, const char* szReqBuf, const size_t nReqMsgLen,
 		const char* szReqVal, const size_t nReqValLen, const netcon::request_e requestType) const;
 
 	void RequestConsoleLog(const bool bWantLog);

--- a/src/engine/server/sv_rcon.cpp
+++ b/src/engine/server/sv_rcon.cpp
@@ -5,6 +5,7 @@
 //===========================================================================//
 
 #include "core/stdafx.h"
+#include "tier0/commandline.h"
 #include "tier1/cvar.h"
 #include "tier1/NetAdr.h"
 #include "tier2/socketcreator.h"
@@ -50,8 +51,8 @@ static ConVar sv_rcon_useloopbacksocket("sv_rcon_useloopbacksocket", "0", FCVAR_
 //-----------------------------------------------------------------------------
 // Purpose: 
 //-----------------------------------------------------------------------------
-CRConServer::CRConServer(void)
-	: m_nConnIndex(0)
+CRConServer::CRConServer(void) : CNetConBase(true)
+	, m_nConnIndex(0)
 	, m_nAuthConnections(0)
 	, m_bInitialized(false)
 	, m_bSocketFailure(false)
@@ -185,6 +186,30 @@ void CRConServer::Think(void)
 }
 
 //-----------------------------------------------------------------------------
+// Purpose: hashes provided password using sha-512
+// Input  : *password - 
+//			length - 
+//			*hashOut - buf must be as large as RCON_SHA512_HASH_SIZE
+// Output : true on success, false otherwise
+//-----------------------------------------------------------------------------
+static bool RCONServer_HashPassword(const char* const password, const size_t length, u8* const hashOut)
+{
+	const int nHashRet = mbedtls_sha512(reinterpret_cast<const u8*>(password), length, hashOut, NULL);
+
+	if (nHashRet == 0)
+	{
+		return true;
+	}
+
+	if (rcon_debug.GetBool())
+	{
+		Error(eDLL_T::SERVER, 0, "SHA-512 algorithm failed on RCON password \"%s\" [%i]\n", password, nHashRet);
+	}
+
+	return false;
+}
+
+//-----------------------------------------------------------------------------
 // Purpose: changes the password
 // Input  : *pszPassword - 
 // Output : true on success, false otherwise
@@ -212,11 +237,16 @@ bool CRConServer::SetPassword(const char* pszPassword)
 	m_bInitialized = false;
 	m_Socket.CloseAllAcceptedSockets();
 
-	const int nHashRet = mbedtls_sha512(reinterpret_cast<const uint8_t*>(pszPassword), nLen, m_PasswordHash, NULL);
-
-	if (nHashRet != 0)
+	if (!RCONServer_HashPassword(pszPassword, nLen, m_PasswordHash))
 	{
-		Error(eDLL_T::SERVER, 0, "SHA-512 algorithm failed on RCON password [%i]\n", nHashRet);
+		// Note: inverted check because if this is cvar is set, the func
+		// RCONServer_HashPassword will print out a more detailed error.
+		// We want to inform the user either way that the hashing of the
+		// provided password has failed.
+		if (!rcon_debug.GetBool())
+		{
+			Error(eDLL_T::SERVER, 0, "Failed to hash RCON server password\n");
+		}
 
 		if (m_Socket.IsListening())
 		{
@@ -264,7 +294,7 @@ void CRConServer::RunFrame(void)
 
 			if (CheckForBan(data))
 			{
-				SendEncoded(data.socket, s_BannedMessage, sizeof(s_BannedMessage)-1, "", 0,
+				SendEncoded(data, s_BannedMessage, sizeof(s_BannedMessage)-1, "", 0,
 					netcon::response_e::SERVERDATA_RESPONSE_AUTH, int(eDLL_T::NETCON));
 
 				Disconnect("banned");
@@ -320,26 +350,46 @@ bool CRConServer::SendToAll(const byte* pMsgBuf, const u32 nMsgLen) const
 // Output: true on success, false otherwise
 //-----------------------------------------------------------------------------
 bool CRConServer::SendEncoded(const char* pResponseMsg, const size_t nResponseMsgLen, const char* pResponseVal, const size_t nResponseValLen,
-	const netcon::response_e responseType, const int nMessageId, const int nMessageType) const
+	const netcon::response_e responseType, const int nMessageId, const int nMessageType)
 {
-	vector<byte> vecMsg;
-	if (!Serialize(vecMsg, pResponseMsg, nResponseMsgLen, pResponseVal, nResponseValLen,
-		responseType, nMessageId, nMessageType))
+	const int nCount = m_Socket.GetAcceptedSocketCount();
+	bool bSuccess = true;
+
+	for (int i = nCount - 1; i >= 0; i--)
 	{
-		return false;
-	}
-	if (!SendToAll(vecMsg.data(), u32(vecMsg.size())))
-	{
-		Error(eDLL_T::SERVER, NO_ERROR, "Failed to send RCON message: (%s)\n", "SOCKET_ERROR");
-		return false;
+		ConnectedNetConsoleData_s& data = m_Socket.GetAcceptedSocketData(i);
+
+		if (!data.authorized || data.inputOnly)
+			continue;
+
+		vector<byte> vecMsg;
+
+		if (!Serialize(data, vecMsg, pResponseMsg, nResponseMsgLen, pResponseVal, nResponseValLen,
+			responseType, nMessageId, nMessageType))
+		{
+			Error(eDLL_T::SERVER, NO_ERROR, "Failed to serialize RCON message for socket #i\n", i);
+			continue;
+		}
+
+		const int ret = ::send(data.socket, (const char*)vecMsg.data(), (i32)vecMsg.size(), MSG_NOSIGNAL);
+
+		if (ret == SOCKET_ERROR)
+		{
+			Error(eDLL_T::SERVER, NO_ERROR, "Failed to send RCON message to socket #i: (%s)\n", i, "SOCKET_ERROR");
+
+			if (!bSuccess)
+			{
+				bSuccess = false;
+			}
+		}
 	}
 
-	return true;
+	return bSuccess;
 }
 
 //-----------------------------------------------------------------------------
 // Purpose: encode and send message to specific socket
-// Input  : hSocket - 
+// Input  : &data - 
 //			*pResponseMsg - 
 //			nResponseMsgLen - 
 //			*pResponseVal - 
@@ -349,17 +399,17 @@ bool CRConServer::SendEncoded(const char* pResponseMsg, const size_t nResponseMs
 //			nMessageType - 
 // Output: true on success, false otherwise
 //-----------------------------------------------------------------------------
-bool CRConServer::SendEncoded(const SocketHandle_t hSocket, 
+bool CRConServer::SendEncoded(ConnectedNetConsoleData_s& data,
 	const char* pResponseMsg, const size_t nResponseMsgLen, const char* pResponseVal, const size_t nResponseValLen,
 	const netcon::response_e responseType, const int nMessageId, const int nMessageType) const
 {
 	vector<byte> vecMsg;
-	if (!Serialize(vecMsg, pResponseMsg, nResponseMsgLen, pResponseVal, nResponseValLen,
+	if (!Serialize(data, vecMsg, pResponseMsg, nResponseMsgLen, pResponseVal, nResponseValLen,
 		responseType, nMessageId, nMessageType))
 	{
 		return false;
 	}
-	if (!Send(hSocket, vecMsg.data(), u32(vecMsg.size())))
+	if (!Send(data.socket, vecMsg.data(), u32(vecMsg.size())))
 	{
 		Error(eDLL_T::SERVER, NO_ERROR, "Failed to send RCON message: (%s)\n", "SOCKET_ERROR");
 		return false;
@@ -370,7 +420,8 @@ bool CRConServer::SendEncoded(const SocketHandle_t hSocket,
 
 //-----------------------------------------------------------------------------
 // Purpose: serializes input
-// Input  : &vecBuf - 
+// Input  : &data - 
+//			&vecBuf - 
 //			*responseMsg - 
 //			nResponseMsgLen - 
 //			*responseVal - 
@@ -380,11 +431,11 @@ bool CRConServer::SendEncoded(const SocketHandle_t hSocket,
 //			nMessageType - 
 // Output : serialized results as string
 //-----------------------------------------------------------------------------
-bool CRConServer::Serialize(vector<byte>& vecBuf, 
+bool CRConServer::Serialize(ConnectedNetConsoleData_s& data, vector<byte>& vecBuf,
 	const char* pResponseMsg, const size_t nResponseMsgLen, const char* pResponseVal, const size_t nResponseValLen,
 	const netcon::response_e responseType, const int nMessageId, const int nMessageType) const
 {
-	return NetconServer_Serialize(this, vecBuf, pResponseMsg, nResponseMsgLen, pResponseVal, nResponseValLen, responseType, nMessageId, nMessageType,
+	return NetconServer_Serialize(this, data, vecBuf, pResponseMsg, nResponseMsgLen, pResponseVal, nResponseValLen, responseType, nMessageId, nMessageType,
 		rcon_encryptframes.GetBool(), rcon_debug.GetBool());
 }
 
@@ -412,7 +463,7 @@ void CRConServer::Authenticate(const netcon::request& request, ConnectedNetConso
 
 		const char* const pSendLogs = (!sv_rcon_sendlogs.GetBool() || data.inputOnly) ? "0" : "1";
 
-		SendEncoded(data.socket, s_AuthMessage, sizeof(s_AuthMessage)-1, pSendLogs, 1,
+		SendEncoded(data, s_AuthMessage, sizeof(s_AuthMessage)-1, pSendLogs, 1,
 			netcon::response_e::SERVERDATA_RESPONSE_AUTH, static_cast<int>(eDLL_T::NETCON));
 	}
 	else // Bad password.
@@ -423,7 +474,7 @@ void CRConServer::Authenticate(const netcon::request& request, ConnectedNetConso
 			Msg(eDLL_T::SERVER, "Bad RCON password attempt from '%s'\n", netAdr.ToString());
 		}
 
-		SendEncoded(data.socket, s_WrongPwMessage, sizeof(s_WrongPwMessage)-1, "", 0,
+		SendEncoded(data, s_WrongPwMessage, sizeof(s_WrongPwMessage)-1, "", 0,
 			netcon::response_e::SERVERDATA_RESPONSE_AUTH, static_cast<int>(eDLL_T::NETCON));
 
 		data.authorized = false;
@@ -439,9 +490,12 @@ void CRConServer::Authenticate(const netcon::request& request, ConnectedNetConso
 //-----------------------------------------------------------------------------
 bool CRConServer::Comparator(const string& svPassword) const
 {
-	uint8_t clientPasswordHash[RCON_SHA512_HASH_SIZE];
-	mbedtls_sha512(reinterpret_cast<const uint8_t*>(svPassword.c_str()), svPassword.length(),
-		clientPasswordHash, NULL);
+	u8 clientPasswordHash[RCON_SHA512_HASH_SIZE];
+
+	if (!RCONServer_HashPassword(svPassword.c_str(), svPassword.length(), clientPasswordHash))
+	{
+		return false;
+	}
 
 	if (memcmp(clientPasswordHash, m_PasswordHash, RCON_SHA512_HASH_SIZE) == 0)
 	{
@@ -453,28 +507,25 @@ bool CRConServer::Comparator(const string& svPassword) const
 
 //-----------------------------------------------------------------------------
 // Purpose: processes received message
-// Input  : *pMsgBuf - 
-//			nMsgLen - 
+// Input  : &data - 
 //			nMaxLen - 
 // Output : true on success, false otherwise
 //-----------------------------------------------------------------------------
-bool CRConServer::ProcessMessage(const byte* pMsgBuf, const u32 nMsgLen, const u32 nMaxLen)
+bool CRConServer::ProcessMessage(ConnectedNetConsoleData_s& data, const u32 nMaxLen)
 {
 	netcon::request request;
 
-	if (!NetconShared_UnpackEnvelope(this, pMsgBuf, nMsgLen, nMaxLen, &request, rcon_debug.GetBool()))
+	if (!NetconShared_UnpackEnvelope(this, data, nMaxLen, &request, rcon_encryptframes.GetBool(), rcon_debug.GetBool()))
 	{
 		Disconnect("received invalid message");
 		return false;
 	}
 
-	ConnectedNetConsoleData_s& data = m_Socket.GetAcceptedSocketData(m_nConnIndex);
-
 	if (!data.authorized &&
 		request.requesttype() != netcon::request_e::SERVERDATA_REQUEST_AUTH)
 	{
 		// Notify netconsole that authentication is required.
-		SendEncoded(data.socket, s_NoAuthMessage, sizeof(s_NoAuthMessage)-1, "", 0,
+		SendEncoded(data, s_NoAuthMessage, sizeof(s_NoAuthMessage)-1, "", 0,
 			netcon::response_e::SERVERDATA_RESPONSE_AUTH, static_cast<int>(eDLL_T::NETCON));
 
 		data.validated = false;

--- a/src/engine/server/sv_rcon.cpp
+++ b/src/engine/server/sv_rcon.cpp
@@ -625,7 +625,14 @@ void CRConServer::Disconnect(const int nIndex, const char* szReason) // NETMGR
 		}
 
 		Msg(eDLL_T::SERVER, "Connection to '%s' lost (%s)\n", netAdr.ToString(), szReason);
-		m_nAuthConnections--;
+
+		if (--m_nAuthConnections < sv_rcon_maxconnections.GetInt())
+		{
+			if (!m_Socket.IsListening())
+			{
+				m_Socket.CreateListenSocket(m_Address);
+			}
+		}
 	}
 
 	m_Socket.CloseAcceptedSocket(nIndex);

--- a/src/engine/server/sv_rcon.cpp
+++ b/src/engine/server/sv_rcon.cpp
@@ -91,6 +91,8 @@ void CRConServer::Init(const char* pPassword, const char* pNetKey)
 	}
 
 	const char* const pszAddress = sv_rcon_useloopbacksocket.GetBool() ? NET_IPV6_LOOPBACK : NET_IPV6_UNSPEC;
+	const bool reuseSocket = CommandLine()->FindParm("-reuse") != 0;
+
 	const static int maxRetries = 64;
 
 	for (int portOffset = 0; portOffset < maxRetries; portOffset++)
@@ -103,7 +105,7 @@ void CRConServer::Init(const char* pPassword, const char* pNetKey)
 			return;
 		}
 
-		m_bSocketFailure = !m_Socket.CreateListenSocket(m_Address);
+		m_bSocketFailure = !m_Socket.CreateListenSocket(m_Address, true, reuseSocket);
 
 		if (!m_bSocketFailure)
 			break; // Successful bind, break out early.

--- a/src/engine/server/sv_rcon.cpp
+++ b/src/engine/server/sv_rcon.cpp
@@ -90,16 +90,24 @@ void CRConServer::Init(const char* pPassword, const char* pNetKey)
 		return;
 	}
 
-	const char* pszAddress = sv_rcon_useloopbacksocket.GetBool() ? NET_IPV6_LOOPBACK : NET_IPV6_UNSPEC;
-	const string addressFormatted = Format("[%s]:%i", pszAddress, hostport->GetInt());
+	const char* const pszAddress = sv_rcon_useloopbacksocket.GetBool() ? NET_IPV6_LOOPBACK : NET_IPV6_UNSPEC;
+	const static int maxRetries = 64;
 
-	if (!m_Address.SetFromString(addressFormatted.c_str(), true))
+	for (int portOffset = 0; portOffset < maxRetries; portOffset++)
 	{
-		Error(eDLL_T::SERVER, 0, "Internal failure while initializing remote server access address ('%s')\n", addressFormatted.c_str());
-		return;
+		const string addressFormatted = Format("[%s]:%i", pszAddress, hostport->GetInt() + portOffset);
+
+		if (!m_Address.SetFromString(addressFormatted.c_str(), true))
+		{
+			Error(eDLL_T::SERVER, 0, "Internal failure while initializing remote server access address ('%s')\n", addressFormatted.c_str());
+			return;
+		}
+
+		m_bSocketFailure = !m_Socket.CreateListenSocket(m_Address);
+
+		if (!m_bSocketFailure)
+			break; // Successful bind, break out early.
 	}
-	
-	m_bSocketFailure = !m_Socket.CreateListenSocket(m_Address);
 
 	if (!m_bSocketFailure)
 	{

--- a/src/engine/server/sv_rcon.h
+++ b/src/engine/server/sv_rcon.h
@@ -29,21 +29,21 @@ public:
 	bool SendEncoded(const char* pResponseMsg, const size_t nResponseMsgLen, const char* pResponseVal, const size_t nResponseValLen,
 		const netcon::response_e responseType,
 		const int nMessageId = static_cast<int>(eDLL_T::NETCON),
-		const int nMessageType = static_cast<int>(LogType_t::LOG_NET)) const;
+		const int nMessageType = static_cast<int>(LogType_t::LOG_NET));
 
-	bool SendEncoded(const SocketHandle_t hSocket, const char* pResponseMsg, const size_t nResponseMsgLen,
+	bool SendEncoded(ConnectedNetConsoleData_s& data, const char* pResponseMsg, const size_t nResponseMsgLen,
 		const char* pResponseVal, const size_t nResponseValLen, const netcon::response_e responseType,
 		const int nMessageId = static_cast<int>(eDLL_T::NETCON),
 		const int nMessageType = static_cast<int>(LogType_t::LOG_NET)) const;
 
 	bool SendToAll(const byte* pMsgBuf, const u32 nMsgLen) const;
-	bool Serialize(vector<byte>& vecBuf, const char* pResponseMsg, const size_t nResponseMsgLen, const char* pResponseVal, const size_t nResponseValLen,
+	bool Serialize(ConnectedNetConsoleData_s& data, vector<byte>& vecBuf, const char* pResponseMsg, const size_t nResponseMsgLen, const char* pResponseVal, const size_t nResponseValLen,
 		const netcon::response_e responseType, const int nMessageId = static_cast<int>(eDLL_T::NETCON), const int nMessageType = static_cast<int>(LogType_t::LOG_NET)) const;
 
 	void Authenticate(const netcon::request& request, ConnectedNetConsoleData_s& data);
 	bool Comparator(const string& svPassword) const;
 
-	virtual bool ProcessMessage(const byte* pMsgBuf, const u32 nMsgLen, const u32 nMaxLen) override;
+	virtual bool ProcessMessage(ConnectedNetConsoleData_s& data, const u32 nMaxLen) override;
 
 	void Execute(const netcon::request& request) const;
 	bool CheckForBan(ConnectedNetConsoleData_s& data);

--- a/src/engine/shared/base_rcon.cpp
+++ b/src/engine/shared/base_rcon.cpp
@@ -159,7 +159,7 @@ bool CNetConBase::ProcessBuffer(ConnectedNetConsoleData_s& data, const byte* pRe
 
 			if (data.payloadRead == data.payloadLen)
 			{
-				if (!ProcessMessage(data.recvBuffer.data(), data.payloadLen, nMaxLen))
+				if (!ProcessMessage(data, nMaxLen))
 					return false;
 
 				// Reset state.
@@ -233,10 +233,10 @@ bool CNetConBase::ProcessBuffer(ConnectedNetConsoleData_s& data, const byte* pRe
 //			nDataLen - 
 // Output : true on success, false otherwise
 //-----------------------------------------------------------------------------
-bool CNetConBase::Encrypt(CryptoContext_s& ctx, const byte* pInBuf, byte* pOutBuf, const u32 nDataLen) const
+bool CNetConBase::Encrypt(CryptoContext_s& ctx, const byte* pInBuf, byte* pOutBuf, const u32 nDataLen, const u8* pAad, const size_t nAadLen) const
 {
 	if (Crypto_GenerateIV(ctx, pInBuf, nDataLen))
-		return Crypto_CTREncrypt(ctx, pInBuf, pOutBuf, m_NetKey, nDataLen);
+		return Crypto_EncryptGCM(ctx, pInBuf, pOutBuf, m_NetKey, nDataLen, pAad, nAadLen);
 
 	Assert(0);
 	return false; // failure
@@ -250,9 +250,9 @@ bool CNetConBase::Encrypt(CryptoContext_s& ctx, const byte* pInBuf, byte* pOutBu
 //			nDataLen - 
 // Output : true on success, false otherwise
 //-----------------------------------------------------------------------------
-bool CNetConBase::Decrypt(CryptoContext_s& ctx, const byte* pInBuf, byte* pOutBuf, const u32 nDataLen) const
+bool CNetConBase::Decrypt(CryptoContext_s& ctx, const byte* pInBuf, byte* pOutBuf, const u32 nDataLen, const u8* pAad, const size_t nAadLen) const
 {
-	return Crypto_CTRDecrypt(ctx, pInBuf, pOutBuf, m_NetKey, nDataLen);
+	return Crypto_DecryptGCM(ctx, pInBuf, pOutBuf, m_NetKey, nDataLen, pAad, nAadLen);
 }
 
 //-----------------------------------------------------------------------------

--- a/src/engine/shared/base_rcon.h
+++ b/src/engine/shared/base_rcon.h
@@ -10,7 +10,7 @@
 class CNetConBase
 {
 public:
-	CNetConBase(void)
+	CNetConBase(const bool isServer) : m_Socket(isServer)
 	{
 		memset(m_NetKey, 0, sizeof(m_NetKey));
 	}
@@ -22,10 +22,10 @@ public:
 	virtual void Disconnect(const char* szReason = nullptr) { NOTE_UNUSED(szReason); };
 
 	virtual bool ProcessBuffer(ConnectedNetConsoleData_s& data, const byte* pRecvBuf, u32 nRecvLen, const u32 nMaxLen);
-	virtual bool ProcessMessage(const byte* /*pMsgBuf*/, const u32 /*nMsgLen*/, const u32 /*nMaxLen*/) { return true; };
+	virtual bool ProcessMessage(ConnectedNetConsoleData_s& /*data*/, const u32 /*nMaxLen*/) { return true; };
 
-	virtual bool Encrypt(CryptoContext_s& ctx, const byte* pInBuf, byte* pOutBuf, const u32 nDataLen) const;
-	virtual bool Decrypt(CryptoContext_s& ctx, const byte* pInBuf, byte* pOutBuf, const u32 nDataLen) const;
+	virtual bool Encrypt(CryptoContext_s& ctx, const byte* pInBuf, byte* pOutBuf, const u32 nDataLen, const u8* pAad, const size_t nAadLen) const;
+	virtual bool Decrypt(CryptoContext_s& ctx, const byte* pInBuf, byte* pOutBuf, const u32 nDataLen, const u8* pAad, const size_t nAadLen) const;
 
 	virtual bool Encode(google::protobuf::MessageLite* pMsg, byte* pMsgBuf, const u32 nMsgLen) const;
 	virtual bool Decode(google::protobuf::MessageLite* pMsg, const byte* pMsgBuf, const u32 nMsgLen) const;

--- a/src/engine/shared/shared_rcon.cpp
+++ b/src/engine/shared/shared_rcon.cpp
@@ -11,6 +11,7 @@
 //-----------------------------------------------------------------------------
 // Purpose: serialize message to vector
 // Input  : *pBase - 
+//			&data - 
 //			&vecBuf - 
 //			*pResponseMsg - 
 //			nResponseMsgLen - 
@@ -23,7 +24,7 @@
 //			bDebug - 
 // Output : true on success, false otherwise
 //-----------------------------------------------------------------------------
-bool NetconServer_Serialize(const CNetConBase* pBase, vector<byte>& vecBuf,
+bool NetconServer_Serialize(const CNetConBase* pBase, ConnectedNetConsoleData_s& data, vector<byte>& vecBuf,
 	const char* pResponseMsg, const size_t nResponseMsgLen, const char* pResponseVal, const size_t nResponseValLen,
 	const netcon::response_e responseType, const int nMessageId, const int nMessageType, const bool bEncrypt, const bool bDebug)
 {
@@ -35,7 +36,7 @@ bool NetconServer_Serialize(const CNetConBase* pBase, vector<byte>& vecBuf,
 	response.set_responsemsg(pResponseMsg, nResponseMsgLen);
 	response.set_responseval(pResponseVal, nResponseValLen);
 
-	if (!NetconShared_PackEnvelope(pBase, vecBuf, (u32)response.ByteSizeLong(), &response, bEncrypt, bDebug))
+	if (!NetconShared_PackEnvelope(pBase, data, vecBuf, (u32)response.ByteSizeLong(), &response, bEncrypt, bDebug))
 	{
 		return false;
 	}
@@ -46,6 +47,7 @@ bool NetconServer_Serialize(const CNetConBase* pBase, vector<byte>& vecBuf,
 //-----------------------------------------------------------------------------
 // Purpose: serialize message to vector
 // Input  : *pBase - 
+//			&data - 
 //			&vecBuf - 
 //			*szReqBuf - 
 //			nReqMsgLen - 
@@ -56,7 +58,7 @@ bool NetconServer_Serialize(const CNetConBase* pBase, vector<byte>& vecBuf,
 //			bDebug - 
 // Output : true on success, false otherwise
 //-----------------------------------------------------------------------------
-bool NetconClient_Serialize(const CNetConBase* pBase, vector<byte>& vecBuf, const char* szReqBuf, const size_t nReqMsgLen,
+bool NetconClient_Serialize(const CNetConBase* pBase, ConnectedNetConsoleData_s& data, vector<byte>& vecBuf, const char* szReqBuf, const size_t nReqMsgLen,
 	const char* szReqVal, const size_t nReqValLen, const netcon::request_e requestType, const bool bEncrypt, const bool bDebug)
 {
 	netcon::request request;
@@ -66,7 +68,7 @@ bool NetconClient_Serialize(const CNetConBase* pBase, vector<byte>& vecBuf, cons
 	request.set_requestmsg(szReqBuf, nReqMsgLen);
 	request.set_requestval(szReqVal, nReqValLen);
 
-	if (!NetconShared_PackEnvelope(pBase, vecBuf, (u32)request.ByteSizeLong(), &request, bEncrypt, bDebug))
+	if (!NetconShared_PackEnvelope(pBase, data, vecBuf, (u32)request.ByteSizeLong(), &request, bEncrypt, bDebug))
 	{
 		return false;
 	}
@@ -119,9 +121,32 @@ bool NetconClient_Connect(CNetConBase* pBase, const char* pHostAdr, const int nH
 	return true;
 }
 
+enum EnvelopeFlow_e : u8
+{
+	EF_S2C, // Server to Client
+	EF_C2S  // Client to Server
+};
+
+struct EnvelopeHeaderAad_s
+{
+	EnvelopeHeaderAad_s(const u64 _seqNr, const u64 _sessionId, const EnvelopeFlow_e _flow)
+	{
+		seqNr = _byteswap_uint64(_seqNr);
+		sessionId = _byteswap_uint64(_sessionId);
+		flow = _flow;
+		memset(_padding, 0, V_ARRAYSIZE(_padding)); // Padding must be deterministic!
+	}
+
+	u64 seqNr;
+	u64 sessionId;
+	EnvelopeFlow_e flow;
+	u8 _padding[7];
+};
+
 //-----------------------------------------------------------------------------
 // Purpose: packs a message envelope
 // Input  : *pBase - 
+//			&data - 
 //			&outMsgBuf - 
 //			nMsgLen - 
 //			*inMsg - 
@@ -129,7 +154,7 @@ bool NetconClient_Connect(CNetConBase* pBase, const char* pHostAdr, const int nH
 //			bDebug - 
 // Output : true on success, false otherwise
 //-----------------------------------------------------------------------------
-bool NetconShared_PackEnvelope(const CNetConBase* pBase, vector<byte>& outMsgBuf, const u32 nMsgLen,
+bool NetconShared_PackEnvelope(const CNetConBase* pBase, ConnectedNetConsoleData_s& data, vector<byte>& outMsgBuf, const u32 nMsgLen,
 	google::protobuf::MessageLite* const inMsg, const bool bEncrypt, const bool bDebug)
 {
 	byte* const encodeBuf = new byte[nMsgLen];
@@ -146,7 +171,12 @@ bool NetconShared_PackEnvelope(const CNetConBase* pBase, vector<byte>& outMsgBuf
 	}
 
 	netcon::envelope envelope;
-	envelope.set_encrypted(bEncrypt);
+	EnvelopeHeaderAad_s aad(data.nextSendSeqNr, data.sessionId, data.isServer ? EF_S2C : EF_C2S);
+
+	netcon::header* const header = envelope.mutable_header();
+
+	header->set_seqnr(data.nextSendSeqNr);
+	header->set_sessionid(data.sessionId);
 
 	const byte* dataBuf = encodeBuf;
 	std::unique_ptr<byte[]> container;
@@ -157,7 +187,7 @@ bool NetconShared_PackEnvelope(const CNetConBase* pBase, vector<byte>& outMsgBuf
 		container.reset(encryptBuf);
 
 		CryptoContext_s ctx;
-		if (!pBase->Encrypt(ctx, encodeBuf, encryptBuf, nMsgLen))
+		if (!pBase->Encrypt(ctx, encodeBuf, encryptBuf, nMsgLen, (const u8*)&aad, sizeof(aad)))
 		{
 			if (bDebug)
 			{
@@ -167,7 +197,9 @@ bool NetconShared_PackEnvelope(const CNetConBase* pBase, vector<byte>& outMsgBuf
 			return false;
 		}
 
-		envelope.set_nonce(ctx.ivData, sizeof(ctx.ivData));
+		envelope.set_iv(ctx.iv, sizeof(ctx.iv));
+		envelope.set_tag(ctx.tag, sizeof(ctx.tag));
+
 		dataBuf = encryptBuf;
 	}
 
@@ -187,32 +219,32 @@ bool NetconShared_PackEnvelope(const CNetConBase* pBase, vector<byte>& outMsgBuf
 		return false;
 	}
 
-	NetConFrameHeader_s* const header = reinterpret_cast<NetConFrameHeader_s*>(scratch);
+	NetConFrameHeader_s* const frameHeader = reinterpret_cast<NetConFrameHeader_s*>(scratch);
 
 	// Write out magic and frame size in network byte order.
-	header->magic = htonl(RCON_FRAME_MAGIC);
-	header->length = htonl(u32(envelopeSize));
+	frameHeader->magic = htonl(RCON_FRAME_MAGIC);
+	frameHeader->length = htonl(u32(envelopeSize));
 
+	data.nextSendSeqNr++;
 	return true;
 }
 
 //-----------------------------------------------------------------------------
 // Purpose: unpacks a message envelope
 // Input  : *pBase - 
-//			*pMsgBuf - 
-//			nMsgLen - 
+//			&data - 
 //			nMaxLen - 
 //			*outMsg - 
 //			bEncrypt - 
 //			bDebug - 
 // Output : true on success, false otherwise
 //-----------------------------------------------------------------------------
-bool NetconShared_UnpackEnvelope(const CNetConBase* pBase, const byte* pMsgBuf, const u32 nMsgLen,
-	const u32 nMaxLen, google::protobuf::MessageLite* const outMsg, const bool bDebug)
+bool NetconShared_UnpackEnvelope(const CNetConBase* pBase, ConnectedNetConsoleData_s& data,
+	const u32 nMaxLen, google::protobuf::MessageLite* const outMsg, const bool bDecrypt, const bool bDebug)
 {
 	netcon::envelope envelope;
 
-	if (!pBase->Decode(&envelope, pMsgBuf, nMsgLen))
+	if (!pBase->Decode(&envelope, data.recvBuffer.data(), data.payloadLen))
 	{
 		if (bDebug)
 		{
@@ -232,33 +264,62 @@ bool NetconShared_UnpackEnvelope(const CNetConBase* pBase, const byte* pMsgBuf, 
 		return false;
 	}
 
-	const byte* netMsg = reinterpret_cast<const byte*>(envelope.data().c_str());
+	const netcon::header& header = envelope.header();
+	const u64 revcSeqNr = header.seqnr();
+
+	if (revcSeqNr != data.lastRecvSeqNr + 1)
+	{
+		Error(eDLL_T::ENGINE, NO_ERROR, "Replay detected for RCON message envelope #%llu; expected sequence #%llu\n",
+			header.seqnr(), data.lastRecvSeqNr + 1);
+
+		return false;
+	}
+
+	data.lastRecvSeqNr = revcSeqNr;
+
+	const byte* const netMsg = reinterpret_cast<const byte*>(envelope.data().c_str());
 	const byte* dataBuf = netMsg;
 
 	std::unique_ptr<byte[]> container;
+	EnvelopeHeaderAad_s aad(header.seqnr(), header.sessionid(), data.isServer ? EF_C2S : EF_S2C);
 
-	if (envelope.encrypted())
+	if (bDecrypt)
 	{
-		byte* decryptBuf = new byte[msgLen];
-		container.reset(decryptBuf);
-
-		const u32 ivLen = (u32)envelope.nonce().size();
+		const u32 ivLen = (u32)envelope.iv().size();
 
 		if (ivLen != sizeof(CryptoIV_t))
 		{
 			if (bDebug)
 			{
-				Error(eDLL_T::ENGINE, NO_ERROR, "Nonce in RCON message envelope is invalid (%u != %u)\n",
+				Error(eDLL_T::ENGINE, NO_ERROR, "IV size in RCON message envelope is incorrect (%u != %u)\n",
 					ivLen, sizeof(CryptoIV_t));
 			}
 
 			return false;
 		}
 
-		CryptoContext_s ctx;
-		memcpy(ctx.ivData, envelope.nonce().data(), ivLen);
+		const u32 tagLen = (u32)envelope.tag().size();
 
-		if (!pBase->Decrypt(ctx, netMsg, decryptBuf, msgLen))
+		if (tagLen != sizeof(CryptoTag_t))
+		{
+			if (bDebug)
+			{
+				Error(eDLL_T::ENGINE, NO_ERROR, "Tag size in RCON message envelope is incorrect (%u != %u)\n",
+					tagLen, sizeof(CryptoTag_t));
+			}
+
+			return false;
+		}
+
+		CryptoContext_s ctx;
+
+		memcpy(ctx.iv, envelope.iv().data(), ivLen);
+		memcpy(ctx.tag, envelope.tag().data(), tagLen);
+
+		byte* const decryptBuf = new byte[msgLen];
+		container.reset(decryptBuf);
+
+		if (!pBase->Decrypt(ctx, netMsg, decryptBuf, msgLen, (const u8*)&aad, sizeof(aad)))
 		{
 			if (bDebug)
 			{

--- a/src/engine/shared/shared_rcon.cpp
+++ b/src/engine/shared/shared_rcon.cpp
@@ -335,10 +335,10 @@ SocketHandle_t NetconShared_GetSocketHandle(CNetConBase* pBase, const int iSocke
 void RCON_KeyChanged_f(IConVar* pConVar, const char* pOldString, float flOldValue, ChangeUserData_t pUserData);
 void RCON_PasswordChanged_f(IConVar* pConVar, const char* pOldString, float flOldValue, ChangeUserData_t pUserData);
 
-ConVar rcon_debug("rcon_debug", "0", FCVAR_RELEASE, "Show rcon debug information ( !slower! )");
+ConVar rcon_debug("rcon_debug", "0", FCVAR_RELEASE, "Show RCON debug information ( !slower! )");
 ConVar rcon_encryptframes("rcon_encryptframes", "1", FCVAR_RELEASE, "Whether to encrypt RCON messages");
 ConVar rcon_key("rcon_key", "", FCVAR_SERVER_CANNOT_QUERY | FCVAR_DONTRECORD | FCVAR_RELEASE, "Base64 remote server access encryption key (random if empty or invalid)", &RCON_KeyChanged_f);
-ConVar rcon_maxframesize("rcon_maxframesize", "2048", FCVAR_RELEASE, "Max number of bytes allowed in a RCON message", true, 128.f, true, 4096.f);
+ConVar rcon_maxframesize("rcon_maxframesize", "2048", FCVAR_RELEASE, "Max number of bytes allowed in an RCON message", true, 128.f, true, 4096.f);
 
 //-----------------------------------------------------------------------------
 // Purpose: change RCON key on server and client

--- a/src/engine/shared/shared_rcon.h
+++ b/src/engine/shared/shared_rcon.h
@@ -17,16 +17,16 @@ extern void RCON_InitClientAndTrySyncKeys();
 #endif // !DEDICATED
 #endif // _TOOLS
 
-bool NetconServer_Serialize(const CNetConBase* pBase, vector<byte>& vecBuf,
+bool NetconServer_Serialize(const CNetConBase* pBase, ConnectedNetConsoleData_s& data, vector<byte>& vecBuf,
 	const char* pResponseMsg, const size_t nResponseMsgLen, const char* pResponseVal, const size_t nResponseValLen,
 	const netcon::response_e responseType, const int nMessageId, const int nMessageType, const bool bEncrypt, const bool bDebug);
 
-bool NetconClient_Serialize(const CNetConBase* pBase, vector<byte>& vecBuf, const char* szReqBuf, const size_t nReqMsgLen,
+bool NetconClient_Serialize(const CNetConBase* pBase, ConnectedNetConsoleData_s& data, vector<byte>& vecBuf, const char* szReqBuf, const size_t nReqMsgLen,
 	const char* szReqVal, const size_t nReqValLen, const netcon::request_e requestType, const bool bEncrypt, const bool bDebug);
 bool NetconClient_Connect(CNetConBase* pBase, const char* pHostAdr, const int nHostPort);
 
-bool NetconShared_PackEnvelope(const CNetConBase* pBase, vector<byte>& outMsgBuf, const u32 nMsgLen, google::protobuf::MessageLite* const inMsg, const bool bEncrypt, const bool bDebug);
-bool NetconShared_UnpackEnvelope(const CNetConBase* pBase, const byte* pMsgBuf, const u32 nMsgLen, const u32 nMaxLen, google::protobuf::MessageLite* const outMsg, const bool bDebug);
+bool NetconShared_PackEnvelope(const CNetConBase* pBase, ConnectedNetConsoleData_s& data, vector<byte>& outMsgBuf, const u32 nMsgLen, google::protobuf::MessageLite* const inMsg, const bool bEncrypt, const bool bDebug);
+bool NetconShared_UnpackEnvelope(const CNetConBase* pBase, ConnectedNetConsoleData_s& data, const u32 nMaxLen, google::protobuf::MessageLite* const outMsg, const bool bDecrypt, const bool bDebug);
 
 ConnectedNetConsoleData_s* NetconShared_GetConnData(CNetConBase* pBase, const int iSocket);
 SocketHandle_t NetconShared_GetSocketHandle(CNetConBase* pBase, const int iSocket);

--- a/src/netconsole/netconsole.cpp
+++ b/src/netconsole/netconsole.cpp
@@ -20,8 +20,8 @@
 //-----------------------------------------------------------------------------
 // Purpose: 
 //-----------------------------------------------------------------------------
-CNetCon::CNetCon(void)
-	: m_bInitialized(false)
+CNetCon::CNetCon(void) : CNetConBase(false)
+	, m_bInitialized(false)
 	, m_bQuitting(false)
 	, m_bPromptConnect(true)
 	, m_bEncryptFrames(false)
@@ -235,8 +235,8 @@ void CNetCon::RunInput(const string& lineInput)
 		}
 
 		vector<byte> vecMsg;
+		ConnectedNetConsoleData_s* pData = GetData();
 
-		const SocketHandle_t hSocket = GetSocket();
 		bool bSend = false;
 
 		if (cmd.ArgC() > 1)
@@ -246,7 +246,7 @@ void CNetCon::RunInput(const string& lineInput)
 				const char* const pass = cmd.Arg(1);
 				const size_t passLen = strlen(pass);
 
-				bSend = Serialize(vecMsg, pass, passLen, "", 0,
+				bSend = Serialize(*pData, vecMsg, pass, passLen, "", 0,
 					netcon::request_e::SERVERDATA_REQUEST_AUTH);
 			}
 			else // Execute command query.
@@ -257,18 +257,18 @@ void CNetCon::RunInput(const string& lineInput)
 				const char* const command = cmd.GetCommandString();
 				const size_t commandLen = strlen(command);
 
-				bSend = Serialize(vecMsg, request, requestLen, command, commandLen,
+				bSend = Serialize(*pData, vecMsg, request, requestLen, command, commandLen,
 					netcon::request_e::SERVERDATA_REQUEST_EXECCOMMAND);
 			}
 		}
 		else // Single arg command query.
 		{
-			bSend = Serialize(vecMsg, lineInput.c_str(), lineInput.length(), "", 0, netcon::request_e::SERVERDATA_REQUEST_EXECCOMMAND);
+			bSend = Serialize(*pData, vecMsg, lineInput.c_str(), lineInput.length(), "", 0, netcon::request_e::SERVERDATA_REQUEST_EXECCOMMAND);
 		}
 
 		if (bSend) // Only send if serialization process was successful.
 		{
-			if (!Send(hSocket, vecMsg.data(), u32(vecMsg.size())))
+			if (!Send(pData->socket, vecMsg.data(), u32(vecMsg.size())))
 			{
 				Error(eDLL_T::CLIENT, NO_ERROR, "Failed to send RCON message: (%s)\n", "SOCKET_ERROR");
 			}
@@ -419,16 +419,15 @@ void CNetCon::Disconnect(const char* szReason)
 
 //-----------------------------------------------------------------------------
 // Purpose: processes received message
-// Input  : *pMsgBuf - 
-//			nMsgLen - 
+// Input  : &data - 
 //			nMaxLen - 
 // Output : true on success, false otherwise
 //-----------------------------------------------------------------------------
-bool CNetCon::ProcessMessage(const byte* pMsgBuf, const u32 nMsgLen, const u32 nMaxLen)
+bool CNetCon::ProcessMessage(ConnectedNetConsoleData_s& data, const u32 nMaxLen)
 {
 	netcon::response response;
 
-	if (!NetconShared_UnpackEnvelope(this, pMsgBuf, nMsgLen, nMaxLen, &response, true))
+	if (!NetconShared_UnpackEnvelope(this, data, nMaxLen, &response, m_bEncryptFrames, true))
 	{
 		Disconnect("received invalid message");
 		return false;
@@ -444,7 +443,7 @@ bool CNetCon::ProcessMessage(const byte* pMsgBuf, const u32 nMsgLen, const u32 n
 			if (!i) // Means we are marked 'input only' on the rcon server.
 			{
 				vector<byte> vecMsg;
-				const bool ret = Serialize(vecMsg, "", 0, "1", 1, netcon::request_e::SERVERDATA_REQUEST_SEND_CONSOLE_LOG);
+				const bool ret = Serialize(data, vecMsg, "", 0, "1", 1, netcon::request_e::SERVERDATA_REQUEST_SEND_CONSOLE_LOG);
 
 				if (ret && !Send(GetSocket(), vecMsg.data(), (u32)vecMsg.size()))
 				{
@@ -474,7 +473,8 @@ bool CNetCon::ProcessMessage(const byte* pMsgBuf, const u32 nMsgLen, const u32 n
 
 //-----------------------------------------------------------------------------
 // Purpose: serializes message to vector
-// Input  : &vecBuf - 
+// Input  : &data,
+//			&vecBuf - 
 //			*szReqBuf - 
 //			nReqMsgLen - 
 //			*svReqVal - 
@@ -482,10 +482,10 @@ bool CNetCon::ProcessMessage(const byte* pMsgBuf, const u32 nMsgLen, const u32 n
 //			requestType - 
 // Output : true on success, false otherwise
 //-----------------------------------------------------------------------------
-bool CNetCon::Serialize(vector<byte>& vecBuf, const char* szReqBuf, const size_t nReqMsgLen,
+bool CNetCon::Serialize(ConnectedNetConsoleData_s& data, vector<byte>& vecBuf, const char* szReqBuf, const size_t nReqMsgLen,
 	const char* szReqVal, const size_t nReqValLen, const netcon::request_e requestType) const
 {
-	return NetconClient_Serialize(this, vecBuf, szReqBuf, nReqMsgLen, szReqVal, nReqValLen, requestType, m_bEncryptFrames, true);
+	return NetconClient_Serialize(this, data, vecBuf, szReqBuf, nReqMsgLen, szReqVal, nReqValLen, requestType, m_bEncryptFrames, true);
 }
 
 //-----------------------------------------------------------------------------
@@ -495,6 +495,15 @@ bool CNetCon::Serialize(vector<byte>& vecBuf, const char* szReqBuf, const size_t
 SocketHandle_t CNetCon::GetSocket(void)
 {
 	return NetconShared_GetSocketHandle(this, 0);
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: retrieves the remote socket data
+// Output : NULL on failure
+//-----------------------------------------------------------------------------
+ConnectedNetConsoleData_s* CNetCon::GetData(void)
+{
+	return NetconShared_GetConnData(this, 0);
 }
 
 //-----------------------------------------------------------------------------

--- a/src/netconsole/netconsole.h
+++ b/src/netconsole/netconsole.h
@@ -36,13 +36,15 @@ public:
 	virtual bool Connect(const char* pHostName, const int nHostPort = SOCKET_ERROR) override;
 	virtual void Disconnect(const char* szReason = nullptr) override;
 
-	virtual bool ProcessMessage(const byte* pMsgBuf, const u32 nMsgLen, const u32 nMaxLen) override;
+	virtual bool ProcessMessage(ConnectedNetConsoleData_s& data, const u32 nMaxLen) override;
 
 	void TrySetKey(const char* const pKey);
-	bool Serialize(vector<byte>& vecBuf, const char* szReqBuf, const size_t nReqMsgLen,
+	bool Serialize(ConnectedNetConsoleData_s& data, vector<byte>& vecBuf, const char* szReqBuf, const size_t nReqMsgLen,
 		const char* szReqVal, const size_t nReqValLen, const netcon::request_e requestType) const;
 
 	SocketHandle_t GetSocket(void);
+	ConnectedNetConsoleData_s* GetData(void);
+
 	bool IsInitialized(void) const;
 	bool IsConnected(void);
 

--- a/src/protoc/netcon.pb.cc
+++ b/src/protoc/netcon.pb.cc
@@ -54,11 +54,26 @@ struct responseDefaultTypeInternal {
   };
 };
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 responseDefaultTypeInternal _response_default_instance_;
+PROTOBUF_CONSTEXPR header::header(
+    ::_pbi::ConstantInitialized): _impl_{
+    /*decltype(_impl_.seqnr_)*/uint64_t{0u}
+  , /*decltype(_impl_.sessionid_)*/uint64_t{0u}
+  , /*decltype(_impl_._cached_size_)*/{}} {}
+struct headerDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR headerDefaultTypeInternal()
+      : _instance(::_pbi::ConstantInitialized{}) {}
+  ~headerDefaultTypeInternal() {}
+  union {
+    header _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 headerDefaultTypeInternal _header_default_instance_;
 PROTOBUF_CONSTEXPR envelope::envelope(
     ::_pbi::ConstantInitialized): _impl_{
-    /*decltype(_impl_.nonce_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
+    /*decltype(_impl_.iv_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
+  , /*decltype(_impl_.tag_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
   , /*decltype(_impl_.data_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
-  , /*decltype(_impl_.encrypted_)*/false
+  , /*decltype(_impl_.header_)*/nullptr
   , /*decltype(_impl_._cached_size_)*/{}} {}
 struct envelopeDefaultTypeInternal {
   PROTOBUF_CONSTEXPR envelopeDefaultTypeInternal()
@@ -944,10 +959,228 @@ std::string response::GetTypeName() const {
 
 // ===================================================================
 
-class envelope::_Internal {
+class header::_Internal {
  public:
 };
 
+header::header(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                         bool is_message_owned)
+  : ::PROTOBUF_NAMESPACE_ID::MessageLite(arena, is_message_owned) {
+  SharedCtor(arena, is_message_owned);
+  // @@protoc_insertion_point(arena_constructor:netcon.header)
+}
+header::header(const header& from)
+  : ::PROTOBUF_NAMESPACE_ID::MessageLite() {
+  header* const _this = this; (void)_this;
+  new (&_impl_) Impl_{
+      decltype(_impl_.seqnr_){}
+    , decltype(_impl_.sessionid_){}
+    , /*decltype(_impl_._cached_size_)*/{}};
+
+  _internal_metadata_.MergeFrom<std::string>(from._internal_metadata_);
+  ::memcpy(&_impl_.seqnr_, &from._impl_.seqnr_,
+    static_cast<size_t>(reinterpret_cast<char*>(&_impl_.sessionid_) -
+    reinterpret_cast<char*>(&_impl_.seqnr_)) + sizeof(_impl_.sessionid_));
+  // @@protoc_insertion_point(copy_constructor:netcon.header)
+}
+
+inline void header::SharedCtor(
+    ::_pb::Arena* arena, bool is_message_owned) {
+  (void)arena;
+  (void)is_message_owned;
+  new (&_impl_) Impl_{
+      decltype(_impl_.seqnr_){uint64_t{0u}}
+    , decltype(_impl_.sessionid_){uint64_t{0u}}
+    , /*decltype(_impl_._cached_size_)*/{}
+  };
+}
+
+header::~header() {
+  // @@protoc_insertion_point(destructor:netcon.header)
+  if (auto *arena = _internal_metadata_.DeleteReturnArena<std::string>()) {
+  (void)arena;
+    return;
+  }
+  SharedDtor();
+}
+
+inline void header::SharedDtor() {
+  GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
+}
+
+void header::SetCachedSize(int size) const {
+  _impl_._cached_size_.Set(size);
+}
+
+void header::Clear() {
+// @@protoc_insertion_point(message_clear_start:netcon.header)
+  uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  ::memset(&_impl_.seqnr_, 0, static_cast<size_t>(
+      reinterpret_cast<char*>(&_impl_.sessionid_) -
+      reinterpret_cast<char*>(&_impl_.seqnr_)) + sizeof(_impl_.sessionid_));
+  _internal_metadata_.Clear<std::string>();
+}
+
+const char* header::_InternalParse(const char* ptr, ::_pbi::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    uint32_t tag;
+    ptr = ::_pbi::ReadTag(ptr, &tag);
+    switch (tag >> 3) {
+      // uint64 seqNr = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 8)) {
+          _impl_.seqnr_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+        } else
+          goto handle_unusual;
+        continue;
+      // uint64 sessionId = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 16)) {
+          _impl_.sessionid_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+        } else
+          goto handle_unusual;
+        continue;
+      default:
+        goto handle_unusual;
+    }  // switch
+  handle_unusual:
+    if ((tag == 0) || ((tag & 7) == 4)) {
+      CHK_(ptr);
+      ctx->SetLastTag(tag);
+      goto message_done;
+    }
+    ptr = UnknownFieldParse(
+        tag,
+        _internal_metadata_.mutable_unknown_fields<std::string>(),
+        ptr, ctx);
+    CHK_(ptr != nullptr);
+  }  // while
+message_done:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto message_done;
+#undef CHK_
+}
+
+uint8_t* header::_InternalSerialize(
+    uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:netcon.header)
+  uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // uint64 seqNr = 1;
+  if (this->_internal_seqnr() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::_pbi::WireFormatLite::WriteUInt64ToArray(1, this->_internal_seqnr(), target);
+  }
+
+  // uint64 sessionId = 2;
+  if (this->_internal_sessionid() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::_pbi::WireFormatLite::WriteUInt64ToArray(2, this->_internal_sessionid(), target);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = stream->WriteRaw(_internal_metadata_.unknown_fields<std::string>(::PROTOBUF_NAMESPACE_ID::internal::GetEmptyString).data(),
+        static_cast<int>(_internal_metadata_.unknown_fields<std::string>(::PROTOBUF_NAMESPACE_ID::internal::GetEmptyString).size()), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:netcon.header)
+  return target;
+}
+
+size_t header::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:netcon.header)
+  size_t total_size = 0;
+
+  uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // uint64 seqNr = 1;
+  if (this->_internal_seqnr() != 0) {
+    total_size += ::_pbi::WireFormatLite::UInt64SizePlusOne(this->_internal_seqnr());
+  }
+
+  // uint64 sessionId = 2;
+  if (this->_internal_sessionid() != 0) {
+    total_size += ::_pbi::WireFormatLite::UInt64SizePlusOne(this->_internal_sessionid());
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    total_size += _internal_metadata_.unknown_fields<std::string>(::PROTOBUF_NAMESPACE_ID::internal::GetEmptyString).size();
+  }
+  int cached_size = ::_pbi::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void header::CheckTypeAndMergeFrom(
+    const ::PROTOBUF_NAMESPACE_ID::MessageLite& from) {
+  MergeFrom(*::_pbi::DownCast<const header*>(
+      &from));
+}
+
+void header::MergeFrom(const header& from) {
+  header* const _this = this;
+  // @@protoc_insertion_point(class_specific_merge_from_start:netcon.header)
+  GOOGLE_DCHECK_NE(&from, _this);
+  uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from._internal_seqnr() != 0) {
+    _this->_internal_set_seqnr(from._internal_seqnr());
+  }
+  if (from._internal_sessionid() != 0) {
+    _this->_internal_set_sessionid(from._internal_sessionid());
+  }
+  _this->_internal_metadata_.MergeFrom<std::string>(from._internal_metadata_);
+}
+
+void header::CopyFrom(const header& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:netcon.header)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool header::IsInitialized() const {
+  return true;
+}
+
+void header::InternalSwap(header* other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::internal::memswap<
+      PROTOBUF_FIELD_OFFSET(header, _impl_.sessionid_)
+      + sizeof(header::_impl_.sessionid_)
+      - PROTOBUF_FIELD_OFFSET(header, _impl_.seqnr_)>(
+          reinterpret_cast<char*>(&_impl_.seqnr_),
+          reinterpret_cast<char*>(&other->_impl_.seqnr_));
+}
+
+std::string header::GetTypeName() const {
+  return "netcon.header";
+}
+
+
+// ===================================================================
+
+class envelope::_Internal {
+ public:
+  static const ::netcon::header& header(const envelope* msg);
+};
+
+const ::netcon::header&
+envelope::_Internal::header(const envelope* msg) {
+  return *msg->_impl_.header_;
+}
 envelope::envelope(::PROTOBUF_NAMESPACE_ID::Arena* arena,
                          bool is_message_owned)
   : ::PROTOBUF_NAMESPACE_ID::MessageLite(arena, is_message_owned) {
@@ -958,18 +1191,27 @@ envelope::envelope(const envelope& from)
   : ::PROTOBUF_NAMESPACE_ID::MessageLite() {
   envelope* const _this = this; (void)_this;
   new (&_impl_) Impl_{
-      decltype(_impl_.nonce_){}
+      decltype(_impl_.iv_){}
+    , decltype(_impl_.tag_){}
     , decltype(_impl_.data_){}
-    , decltype(_impl_.encrypted_){}
+    , decltype(_impl_.header_){nullptr}
     , /*decltype(_impl_._cached_size_)*/{}};
 
   _internal_metadata_.MergeFrom<std::string>(from._internal_metadata_);
-  _impl_.nonce_.InitDefault();
+  _impl_.iv_.InitDefault();
   #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
-    _impl_.nonce_.Set("", GetArenaForAllocation());
+    _impl_.iv_.Set("", GetArenaForAllocation());
   #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
-  if (!from._internal_nonce().empty()) {
-    _this->_impl_.nonce_.Set(from._internal_nonce(), 
+  if (!from._internal_iv().empty()) {
+    _this->_impl_.iv_.Set(from._internal_iv(), 
+      _this->GetArenaForAllocation());
+  }
+  _impl_.tag_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.tag_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (!from._internal_tag().empty()) {
+    _this->_impl_.tag_.Set(from._internal_tag(), 
       _this->GetArenaForAllocation());
   }
   _impl_.data_.InitDefault();
@@ -980,7 +1222,9 @@ envelope::envelope(const envelope& from)
     _this->_impl_.data_.Set(from._internal_data(), 
       _this->GetArenaForAllocation());
   }
-  _this->_impl_.encrypted_ = from._impl_.encrypted_;
+  if (from._internal_has_header()) {
+    _this->_impl_.header_ = new ::netcon::header(*from._impl_.header_);
+  }
   // @@protoc_insertion_point(copy_constructor:netcon.envelope)
 }
 
@@ -989,14 +1233,19 @@ inline void envelope::SharedCtor(
   (void)arena;
   (void)is_message_owned;
   new (&_impl_) Impl_{
-      decltype(_impl_.nonce_){}
+      decltype(_impl_.iv_){}
+    , decltype(_impl_.tag_){}
     , decltype(_impl_.data_){}
-    , decltype(_impl_.encrypted_){false}
+    , decltype(_impl_.header_){nullptr}
     , /*decltype(_impl_._cached_size_)*/{}
   };
-  _impl_.nonce_.InitDefault();
+  _impl_.iv_.InitDefault();
   #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
-    _impl_.nonce_.Set("", GetArenaForAllocation());
+    _impl_.iv_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  _impl_.tag_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.tag_.Set("", GetArenaForAllocation());
   #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
   _impl_.data_.InitDefault();
   #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
@@ -1015,8 +1264,10 @@ envelope::~envelope() {
 
 inline void envelope::SharedDtor() {
   GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
-  _impl_.nonce_.Destroy();
+  _impl_.iv_.Destroy();
+  _impl_.tag_.Destroy();
   _impl_.data_.Destroy();
+  if (this != internal_default_instance()) delete _impl_.header_;
 }
 
 void envelope::SetCachedSize(int size) const {
@@ -1029,9 +1280,13 @@ void envelope::Clear() {
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
 
-  _impl_.nonce_.ClearToEmpty();
+  _impl_.iv_.ClearToEmpty();
+  _impl_.tag_.ClearToEmpty();
   _impl_.data_.ClearToEmpty();
-  _impl_.encrypted_ = false;
+  if (GetArenaForAllocation() == nullptr && _impl_.header_ != nullptr) {
+    delete _impl_.header_;
+  }
+  _impl_.header_ = nullptr;
   _internal_metadata_.Clear<std::string>();
 }
 
@@ -1041,26 +1296,35 @@ const char* envelope::_InternalParse(const char* ptr, ::_pbi::ParseContext* ctx)
     uint32_t tag;
     ptr = ::_pbi::ReadTag(ptr, &tag);
     switch (tag >> 3) {
-      // bool encrypted = 1;
+      // .netcon.header header = 1;
       case 1:
-        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 8)) {
-          _impl_.encrypted_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 10)) {
+          ptr = ctx->ParseMessage(_internal_mutable_header(), ptr);
           CHK_(ptr);
         } else
           goto handle_unusual;
         continue;
-      // bytes nonce = 2;
+      // bytes iv = 2;
       case 2:
         if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 18)) {
-          auto str = _internal_mutable_nonce();
+          auto str = _internal_mutable_iv();
           ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
           CHK_(ptr);
         } else
           goto handle_unusual;
         continue;
-      // bytes data = 3;
+      // bytes tag = 3;
       case 3:
         if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 26)) {
+          auto str = _internal_mutable_tag();
+          ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(ptr);
+        } else
+          goto handle_unusual;
+        continue;
+      // bytes data = 4;
+      case 4:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 34)) {
           auto str = _internal_mutable_data();
           ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
           CHK_(ptr);
@@ -1096,22 +1360,29 @@ uint8_t* envelope::_InternalSerialize(
   uint32_t cached_has_bits = 0;
   (void) cached_has_bits;
 
-  // bool encrypted = 1;
-  if (this->_internal_encrypted() != 0) {
-    target = stream->EnsureSpace(target);
-    target = ::_pbi::WireFormatLite::WriteBoolToArray(1, this->_internal_encrypted(), target);
+  // .netcon.header header = 1;
+  if (this->_internal_has_header()) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(1, _Internal::header(this),
+        _Internal::header(this).GetCachedSize(), target, stream);
   }
 
-  // bytes nonce = 2;
-  if (!this->_internal_nonce().empty()) {
+  // bytes iv = 2;
+  if (!this->_internal_iv().empty()) {
     target = stream->WriteBytesMaybeAliased(
-        2, this->_internal_nonce(), target);
+        2, this->_internal_iv(), target);
   }
 
-  // bytes data = 3;
+  // bytes tag = 3;
+  if (!this->_internal_tag().empty()) {
+    target = stream->WriteBytesMaybeAliased(
+        3, this->_internal_tag(), target);
+  }
+
+  // bytes data = 4;
   if (!this->_internal_data().empty()) {
     target = stream->WriteBytesMaybeAliased(
-        3, this->_internal_data(), target);
+        4, this->_internal_data(), target);
   }
 
   if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
@@ -1130,23 +1401,32 @@ size_t envelope::ByteSizeLong() const {
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
 
-  // bytes nonce = 2;
-  if (!this->_internal_nonce().empty()) {
+  // bytes iv = 2;
+  if (!this->_internal_iv().empty()) {
     total_size += 1 +
       ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::BytesSize(
-        this->_internal_nonce());
+        this->_internal_iv());
   }
 
-  // bytes data = 3;
+  // bytes tag = 3;
+  if (!this->_internal_tag().empty()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::BytesSize(
+        this->_internal_tag());
+  }
+
+  // bytes data = 4;
   if (!this->_internal_data().empty()) {
     total_size += 1 +
       ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::BytesSize(
         this->_internal_data());
   }
 
-  // bool encrypted = 1;
-  if (this->_internal_encrypted() != 0) {
-    total_size += 1 + 1;
+  // .netcon.header header = 1;
+  if (this->_internal_has_header()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *_impl_.header_);
   }
 
   if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
@@ -1170,14 +1450,18 @@ void envelope::MergeFrom(const envelope& from) {
   uint32_t cached_has_bits = 0;
   (void) cached_has_bits;
 
-  if (!from._internal_nonce().empty()) {
-    _this->_internal_set_nonce(from._internal_nonce());
+  if (!from._internal_iv().empty()) {
+    _this->_internal_set_iv(from._internal_iv());
+  }
+  if (!from._internal_tag().empty()) {
+    _this->_internal_set_tag(from._internal_tag());
   }
   if (!from._internal_data().empty()) {
     _this->_internal_set_data(from._internal_data());
   }
-  if (from._internal_encrypted() != 0) {
-    _this->_internal_set_encrypted(from._internal_encrypted());
+  if (from._internal_has_header()) {
+    _this->_internal_mutable_header()->::netcon::header::MergeFrom(
+        from._internal_header());
   }
   _this->_internal_metadata_.MergeFrom<std::string>(from._internal_metadata_);
 }
@@ -1199,14 +1483,18 @@ void envelope::InternalSwap(envelope* other) {
   auto* rhs_arena = other->GetArenaForAllocation();
   _internal_metadata_.InternalSwap(&other->_internal_metadata_);
   ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
-      &_impl_.nonce_, lhs_arena,
-      &other->_impl_.nonce_, rhs_arena
+      &_impl_.iv_, lhs_arena,
+      &other->_impl_.iv_, rhs_arena
+  );
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
+      &_impl_.tag_, lhs_arena,
+      &other->_impl_.tag_, rhs_arena
   );
   ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
       &_impl_.data_, lhs_arena,
       &other->_impl_.data_, rhs_arena
   );
-  swap(_impl_.encrypted_, other->_impl_.encrypted_);
+  swap(_impl_.header_, other->_impl_.header_);
 }
 
 std::string envelope::GetTypeName() const {
@@ -1224,6 +1512,10 @@ Arena::CreateMaybeMessage< ::netcon::request >(Arena* arena) {
 template<> PROTOBUF_NOINLINE ::netcon::response*
 Arena::CreateMaybeMessage< ::netcon::response >(Arena* arena) {
   return Arena::CreateMessageInternal< ::netcon::response >(arena);
+}
+template<> PROTOBUF_NOINLINE ::netcon::header*
+Arena::CreateMaybeMessage< ::netcon::header >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::netcon::header >(arena);
 }
 template<> PROTOBUF_NOINLINE ::netcon::envelope*
 Arena::CreateMaybeMessage< ::netcon::envelope >(Arena* arena) {

--- a/src/protoc/netcon.pb.h
+++ b/src/protoc/netcon.pb.h
@@ -46,6 +46,9 @@ namespace netcon {
 class envelope;
 struct envelopeDefaultTypeInternal;
 extern envelopeDefaultTypeInternal _envelope_default_instance_;
+class header;
+struct headerDefaultTypeInternal;
+extern headerDefaultTypeInternal _header_default_instance_;
 class request;
 struct requestDefaultTypeInternal;
 extern requestDefaultTypeInternal _request_default_instance_;
@@ -55,6 +58,7 @@ extern responseDefaultTypeInternal _response_default_instance_;
 }  // namespace netcon
 PROTOBUF_NAMESPACE_OPEN
 template<> ::netcon::envelope* Arena::CreateMaybeMessage<::netcon::envelope>(Arena*);
+template<> ::netcon::header* Arena::CreateMaybeMessage<::netcon::header>(Arena*);
 template<> ::netcon::request* Arena::CreateMaybeMessage<::netcon::request>(Arena*);
 template<> ::netcon::response* Arena::CreateMaybeMessage<::netcon::response>(Arena*);
 PROTOBUF_NAMESPACE_CLOSE
@@ -515,6 +519,147 @@ class response final :
 };
 // -------------------------------------------------------------------
 
+class header final :
+    public ::PROTOBUF_NAMESPACE_ID::MessageLite /* @@protoc_insertion_point(class_definition:netcon.header) */ {
+ public:
+  inline header() : header(nullptr) {}
+  ~header() override;
+  explicit PROTOBUF_CONSTEXPR header(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  header(const header& from);
+  header(header&& from) noexcept
+    : header() {
+    *this = ::std::move(from);
+  }
+
+  inline header& operator=(const header& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline header& operator=(header&& from) noexcept {
+    if (this == &from) return *this;
+    if (GetOwningArena() == from.GetOwningArena()
+  #ifdef PROTOBUF_FORCE_COPY_IN_MOVE
+        && GetOwningArena() != nullptr
+  #endif  // !PROTOBUF_FORCE_COPY_IN_MOVE
+    ) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const header& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const header* internal_default_instance() {
+    return reinterpret_cast<const header*>(
+               &_header_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    2;
+
+  friend void swap(header& a, header& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(header* other) {
+    if (other == this) return;
+  #ifdef PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetOwningArena() != nullptr &&
+        GetOwningArena() == other->GetOwningArena()) {
+   #else  // PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetOwningArena() == other->GetOwningArena()) {
+  #endif  // !PROTOBUF_FORCE_COPY_IN_SWAP
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(header* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetOwningArena() == other->GetOwningArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  header* New(::PROTOBUF_NAMESPACE_ID::Arena* arena = nullptr) const final {
+    return CreateMaybeMessage<header>(arena);
+  }
+  void CheckTypeAndMergeFrom(const ::PROTOBUF_NAMESPACE_ID::MessageLite& from)  final;
+  void CopyFrom(const header& from);
+  void MergeFrom(const header& from);
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  uint8_t* _InternalSerialize(
+      uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::PROTOBUF_NAMESPACE_ID::Arena* arena, bool is_message_owned);
+  void SharedDtor();
+  void SetCachedSize(int size) const;
+  void InternalSwap(header* other);
+
+  private:
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "netcon.header";
+  }
+  protected:
+  explicit header(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                       bool is_message_owned = false);
+  public:
+
+  std::string GetTypeName() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kSeqNrFieldNumber = 1,
+    kSessionIdFieldNumber = 2,
+  };
+  // uint64 seqNr = 1;
+  void clear_seqnr();
+  uint64_t seqnr() const;
+  void set_seqnr(uint64_t value);
+  private:
+  uint64_t _internal_seqnr() const;
+  void _internal_set_seqnr(uint64_t value);
+  public:
+
+  // uint64 sessionId = 2;
+  void clear_sessionid();
+  uint64_t sessionid() const;
+  void set_sessionid(uint64_t value);
+  private:
+  uint64_t _internal_sessionid() const;
+  void _internal_set_sessionid(uint64_t value);
+  public:
+
+  // @@protoc_insertion_point(class_scope:netcon.header)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  struct Impl_ {
+    uint64_t seqnr_;
+    uint64_t sessionid_;
+    mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_netcon_2eproto;
+};
+// -------------------------------------------------------------------
+
 class envelope final :
     public ::PROTOBUF_NAMESPACE_ID::MessageLite /* @@protoc_insertion_point(class_definition:netcon.envelope) */ {
  public:
@@ -554,7 +699,7 @@ class envelope final :
                &_envelope_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    2;
+    3;
 
   friend void swap(envelope& a, envelope& b) {
     a.Swap(&b);
@@ -618,25 +763,40 @@ class envelope final :
   // accessors -------------------------------------------------------
 
   enum : int {
-    kNonceFieldNumber = 2,
-    kDataFieldNumber = 3,
-    kEncryptedFieldNumber = 1,
+    kIvFieldNumber = 2,
+    kTagFieldNumber = 3,
+    kDataFieldNumber = 4,
+    kHeaderFieldNumber = 1,
   };
-  // bytes nonce = 2;
-  void clear_nonce();
-  const std::string& nonce() const;
+  // bytes iv = 2;
+  void clear_iv();
+  const std::string& iv() const;
   template <typename ArgT0 = const std::string&, typename... ArgT>
-  void set_nonce(ArgT0&& arg0, ArgT... args);
-  std::string* mutable_nonce();
-  PROTOBUF_NODISCARD std::string* release_nonce();
-  void set_allocated_nonce(std::string* nonce);
+  void set_iv(ArgT0&& arg0, ArgT... args);
+  std::string* mutable_iv();
+  PROTOBUF_NODISCARD std::string* release_iv();
+  void set_allocated_iv(std::string* iv);
   private:
-  const std::string& _internal_nonce() const;
-  inline PROTOBUF_ALWAYS_INLINE void _internal_set_nonce(const std::string& value);
-  std::string* _internal_mutable_nonce();
+  const std::string& _internal_iv() const;
+  inline PROTOBUF_ALWAYS_INLINE void _internal_set_iv(const std::string& value);
+  std::string* _internal_mutable_iv();
   public:
 
-  // bytes data = 3;
+  // bytes tag = 3;
+  void clear_tag();
+  const std::string& tag() const;
+  template <typename ArgT0 = const std::string&, typename... ArgT>
+  void set_tag(ArgT0&& arg0, ArgT... args);
+  std::string* mutable_tag();
+  PROTOBUF_NODISCARD std::string* release_tag();
+  void set_allocated_tag(std::string* tag);
+  private:
+  const std::string& _internal_tag() const;
+  inline PROTOBUF_ALWAYS_INLINE void _internal_set_tag(const std::string& value);
+  std::string* _internal_mutable_tag();
+  public:
+
+  // bytes data = 4;
   void clear_data();
   const std::string& data() const;
   template <typename ArgT0 = const std::string&, typename... ArgT>
@@ -650,14 +810,23 @@ class envelope final :
   std::string* _internal_mutable_data();
   public:
 
-  // bool encrypted = 1;
-  void clear_encrypted();
-  bool encrypted() const;
-  void set_encrypted(bool value);
+  // .netcon.header header = 1;
+  bool has_header() const;
   private:
-  bool _internal_encrypted() const;
-  void _internal_set_encrypted(bool value);
+  bool _internal_has_header() const;
   public:
+  void clear_header();
+  const ::netcon::header& header() const;
+  PROTOBUF_NODISCARD ::netcon::header* release_header();
+  ::netcon::header* mutable_header();
+  void set_allocated_header(::netcon::header* header);
+  private:
+  const ::netcon::header& _internal_header() const;
+  ::netcon::header* _internal_mutable_header();
+  public:
+  void unsafe_arena_set_allocated_header(
+      ::netcon::header* header);
+  ::netcon::header* unsafe_arena_release_header();
 
   // @@protoc_insertion_point(class_scope:netcon.envelope)
  private:
@@ -667,9 +836,10 @@ class envelope final :
   typedef void InternalArenaConstructable_;
   typedef void DestructorSkippable_;
   struct Impl_ {
-    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr nonce_;
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr iv_;
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr tag_;
     ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr data_;
-    bool encrypted_;
+    ::netcon::header* header_;
     mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
   };
   union { Impl_ _impl_; };
@@ -1132,79 +1302,243 @@ inline void response::set_allocated_responseval(std::string* responseval) {
 
 // -------------------------------------------------------------------
 
+// header
+
+// uint64 seqNr = 1;
+inline void header::clear_seqnr() {
+  _impl_.seqnr_ = uint64_t{0u};
+}
+inline uint64_t header::_internal_seqnr() const {
+  return _impl_.seqnr_;
+}
+inline uint64_t header::seqnr() const {
+  // @@protoc_insertion_point(field_get:netcon.header.seqNr)
+  return _internal_seqnr();
+}
+inline void header::_internal_set_seqnr(uint64_t value) {
+  
+  _impl_.seqnr_ = value;
+}
+inline void header::set_seqnr(uint64_t value) {
+  _internal_set_seqnr(value);
+  // @@protoc_insertion_point(field_set:netcon.header.seqNr)
+}
+
+// uint64 sessionId = 2;
+inline void header::clear_sessionid() {
+  _impl_.sessionid_ = uint64_t{0u};
+}
+inline uint64_t header::_internal_sessionid() const {
+  return _impl_.sessionid_;
+}
+inline uint64_t header::sessionid() const {
+  // @@protoc_insertion_point(field_get:netcon.header.sessionId)
+  return _internal_sessionid();
+}
+inline void header::_internal_set_sessionid(uint64_t value) {
+  
+  _impl_.sessionid_ = value;
+}
+inline void header::set_sessionid(uint64_t value) {
+  _internal_set_sessionid(value);
+  // @@protoc_insertion_point(field_set:netcon.header.sessionId)
+}
+
+// -------------------------------------------------------------------
+
 // envelope
 
-// bool encrypted = 1;
-inline void envelope::clear_encrypted() {
-  _impl_.encrypted_ = false;
+// .netcon.header header = 1;
+inline bool envelope::_internal_has_header() const {
+  return this != internal_default_instance() && _impl_.header_ != nullptr;
 }
-inline bool envelope::_internal_encrypted() const {
-  return _impl_.encrypted_;
+inline bool envelope::has_header() const {
+  return _internal_has_header();
 }
-inline bool envelope::encrypted() const {
-  // @@protoc_insertion_point(field_get:netcon.envelope.encrypted)
-  return _internal_encrypted();
+inline void envelope::clear_header() {
+  if (GetArenaForAllocation() == nullptr && _impl_.header_ != nullptr) {
+    delete _impl_.header_;
+  }
+  _impl_.header_ = nullptr;
 }
-inline void envelope::_internal_set_encrypted(bool value) {
-  
-  _impl_.encrypted_ = value;
+inline const ::netcon::header& envelope::_internal_header() const {
+  const ::netcon::header* p = _impl_.header_;
+  return p != nullptr ? *p : reinterpret_cast<const ::netcon::header&>(
+      ::netcon::_header_default_instance_);
 }
-inline void envelope::set_encrypted(bool value) {
-  _internal_set_encrypted(value);
-  // @@protoc_insertion_point(field_set:netcon.envelope.encrypted)
+inline const ::netcon::header& envelope::header() const {
+  // @@protoc_insertion_point(field_get:netcon.envelope.header)
+  return _internal_header();
 }
-
-// bytes nonce = 2;
-inline void envelope::clear_nonce() {
-  _impl_.nonce_.ClearToEmpty();
-}
-inline const std::string& envelope::nonce() const {
-  // @@protoc_insertion_point(field_get:netcon.envelope.nonce)
-  return _internal_nonce();
-}
-template <typename ArgT0, typename... ArgT>
-inline PROTOBUF_ALWAYS_INLINE
-void envelope::set_nonce(ArgT0&& arg0, ArgT... args) {
- 
- _impl_.nonce_.SetBytes(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
-  // @@protoc_insertion_point(field_set:netcon.envelope.nonce)
-}
-inline std::string* envelope::mutable_nonce() {
-  std::string* _s = _internal_mutable_nonce();
-  // @@protoc_insertion_point(field_mutable:netcon.envelope.nonce)
-  return _s;
-}
-inline const std::string& envelope::_internal_nonce() const {
-  return _impl_.nonce_.Get();
-}
-inline void envelope::_internal_set_nonce(const std::string& value) {
-  
-  _impl_.nonce_.Set(value, GetArenaForAllocation());
-}
-inline std::string* envelope::_internal_mutable_nonce() {
-  
-  return _impl_.nonce_.Mutable(GetArenaForAllocation());
-}
-inline std::string* envelope::release_nonce() {
-  // @@protoc_insertion_point(field_release:netcon.envelope.nonce)
-  return _impl_.nonce_.Release();
-}
-inline void envelope::set_allocated_nonce(std::string* nonce) {
-  if (nonce != nullptr) {
+inline void envelope::unsafe_arena_set_allocated_header(
+    ::netcon::header* header) {
+  if (GetArenaForAllocation() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(_impl_.header_);
+  }
+  _impl_.header_ = header;
+  if (header) {
     
   } else {
     
   }
-  _impl_.nonce_.SetAllocated(nonce, GetArenaForAllocation());
-#ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
-  if (_impl_.nonce_.IsDefault()) {
-    _impl_.nonce_.Set("", GetArenaForAllocation());
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:netcon.envelope.header)
+}
+inline ::netcon::header* envelope::release_header() {
+  
+  ::netcon::header* temp = _impl_.header_;
+  _impl_.header_ = nullptr;
+#ifdef PROTOBUF_FORCE_COPY_IN_RELEASE
+  auto* old =  reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(temp);
+  temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  if (GetArenaForAllocation() == nullptr) { delete old; }
+#else  // PROTOBUF_FORCE_COPY_IN_RELEASE
+  if (GetArenaForAllocation() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
   }
-#endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
-  // @@protoc_insertion_point(field_set_allocated:netcon.envelope.nonce)
+#endif  // !PROTOBUF_FORCE_COPY_IN_RELEASE
+  return temp;
+}
+inline ::netcon::header* envelope::unsafe_arena_release_header() {
+  // @@protoc_insertion_point(field_release:netcon.envelope.header)
+  
+  ::netcon::header* temp = _impl_.header_;
+  _impl_.header_ = nullptr;
+  return temp;
+}
+inline ::netcon::header* envelope::_internal_mutable_header() {
+  
+  if (_impl_.header_ == nullptr) {
+    auto* p = CreateMaybeMessage<::netcon::header>(GetArenaForAllocation());
+    _impl_.header_ = p;
+  }
+  return _impl_.header_;
+}
+inline ::netcon::header* envelope::mutable_header() {
+  ::netcon::header* _msg = _internal_mutable_header();
+  // @@protoc_insertion_point(field_mutable:netcon.envelope.header)
+  return _msg;
+}
+inline void envelope::set_allocated_header(::netcon::header* header) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArenaForAllocation();
+  if (message_arena == nullptr) {
+    delete _impl_.header_;
+  }
+  if (header) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+        ::PROTOBUF_NAMESPACE_ID::Arena::InternalGetOwningArena(header);
+    if (message_arena != submessage_arena) {
+      header = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, header, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  _impl_.header_ = header;
+  // @@protoc_insertion_point(field_set_allocated:netcon.envelope.header)
 }
 
-// bytes data = 3;
+// bytes iv = 2;
+inline void envelope::clear_iv() {
+  _impl_.iv_.ClearToEmpty();
+}
+inline const std::string& envelope::iv() const {
+  // @@protoc_insertion_point(field_get:netcon.envelope.iv)
+  return _internal_iv();
+}
+template <typename ArgT0, typename... ArgT>
+inline PROTOBUF_ALWAYS_INLINE
+void envelope::set_iv(ArgT0&& arg0, ArgT... args) {
+ 
+ _impl_.iv_.SetBytes(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
+  // @@protoc_insertion_point(field_set:netcon.envelope.iv)
+}
+inline std::string* envelope::mutable_iv() {
+  std::string* _s = _internal_mutable_iv();
+  // @@protoc_insertion_point(field_mutable:netcon.envelope.iv)
+  return _s;
+}
+inline const std::string& envelope::_internal_iv() const {
+  return _impl_.iv_.Get();
+}
+inline void envelope::_internal_set_iv(const std::string& value) {
+  
+  _impl_.iv_.Set(value, GetArenaForAllocation());
+}
+inline std::string* envelope::_internal_mutable_iv() {
+  
+  return _impl_.iv_.Mutable(GetArenaForAllocation());
+}
+inline std::string* envelope::release_iv() {
+  // @@protoc_insertion_point(field_release:netcon.envelope.iv)
+  return _impl_.iv_.Release();
+}
+inline void envelope::set_allocated_iv(std::string* iv) {
+  if (iv != nullptr) {
+    
+  } else {
+    
+  }
+  _impl_.iv_.SetAllocated(iv, GetArenaForAllocation());
+#ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (_impl_.iv_.IsDefault()) {
+    _impl_.iv_.Set("", GetArenaForAllocation());
+  }
+#endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  // @@protoc_insertion_point(field_set_allocated:netcon.envelope.iv)
+}
+
+// bytes tag = 3;
+inline void envelope::clear_tag() {
+  _impl_.tag_.ClearToEmpty();
+}
+inline const std::string& envelope::tag() const {
+  // @@protoc_insertion_point(field_get:netcon.envelope.tag)
+  return _internal_tag();
+}
+template <typename ArgT0, typename... ArgT>
+inline PROTOBUF_ALWAYS_INLINE
+void envelope::set_tag(ArgT0&& arg0, ArgT... args) {
+ 
+ _impl_.tag_.SetBytes(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
+  // @@protoc_insertion_point(field_set:netcon.envelope.tag)
+}
+inline std::string* envelope::mutable_tag() {
+  std::string* _s = _internal_mutable_tag();
+  // @@protoc_insertion_point(field_mutable:netcon.envelope.tag)
+  return _s;
+}
+inline const std::string& envelope::_internal_tag() const {
+  return _impl_.tag_.Get();
+}
+inline void envelope::_internal_set_tag(const std::string& value) {
+  
+  _impl_.tag_.Set(value, GetArenaForAllocation());
+}
+inline std::string* envelope::_internal_mutable_tag() {
+  
+  return _impl_.tag_.Mutable(GetArenaForAllocation());
+}
+inline std::string* envelope::release_tag() {
+  // @@protoc_insertion_point(field_release:netcon.envelope.tag)
+  return _impl_.tag_.Release();
+}
+inline void envelope::set_allocated_tag(std::string* tag) {
+  if (tag != nullptr) {
+    
+  } else {
+    
+  }
+  _impl_.tag_.SetAllocated(tag, GetArenaForAllocation());
+#ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (_impl_.tag_.IsDefault()) {
+    _impl_.tag_.Set("", GetArenaForAllocation());
+  }
+#endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  // @@protoc_insertion_point(field_set_allocated:netcon.envelope.tag)
+}
+
+// bytes data = 4;
 inline void envelope::clear_data() {
   _impl_.data_.ClearToEmpty();
 }
@@ -1257,6 +1591,8 @@ inline void envelope::set_allocated_data(std::string* data) {
 #ifdef __GNUC__
   #pragma GCC diagnostic pop
 #endif  // __GNUC__
+// -------------------------------------------------------------------
+
 // -------------------------------------------------------------------
 
 // -------------------------------------------------------------------

--- a/src/public/tier1/NetAdr.h
+++ b/src/public/tier1/NetAdr.h
@@ -23,7 +23,7 @@ public:
 	inline void	SetPort(const uint16_t newport)     { port = newport; }
 	inline void	SetType(const netadrtype_t newtype) { type = newtype; }
 
-	bool	SetFromSockadr(struct sockaddr_storage* s);
+	bool	SetFromSockadr(struct sockaddr_in6* s);
 	bool	SetFromString(const char* const pch, const bool bUseDNS = false);
 
 	inline netadrtype_t	GetType(void) const { return type; }
@@ -37,7 +37,7 @@ public:
 	const char*	ToString(const bool onlyBase = false) const;
 	size_t		ToString(char* const pchBuffer, const size_t unBufferSize, const bool onlyBase = false) const;
 	void		ToAdrinfo(addrinfo* pHint) const;
-	void		ToSockadr(struct sockaddr_storage* const s) const;
+	void		ToSockadr(struct sockaddr_in6* const s) const;
 
 private:
 	netadrtype_t type;

--- a/src/public/tier2/cryptutils.h
+++ b/src/public/tier2/cryptutils.h
@@ -5,6 +5,7 @@ bool Plat_GenerateRandom(unsigned char* pBuffer, const uint32_t nBufLen, const c
 
 typedef unsigned char CryptoIV_t[16];
 typedef unsigned char CryptoKey_t[16];
+typedef unsigned char CryptoTag_t[16];
 
 struct CryptoContext_s
 {
@@ -12,17 +13,22 @@ struct CryptoContext_s
 		: keyBits(setKeyBits)
 	{
 		Assert(setKeyBits == 128 || setKeyBits == 192 || setKeyBits == 256);
-		memset(ivData, 0, sizeof(ivData));
+		memset(iv, 0, sizeof(iv));
 	}
 
-	CryptoIV_t ivData;
+	CryptoIV_t iv;
+	CryptoTag_t tag;
 	int keyBits;
 };
 
-bool Crypto_GenerateIV(CryptoContext_s& ctx, const unsigned char* const data, const size_t size);
-bool Crypto_CTREncrypt(CryptoContext_s& ctx, const unsigned char* const inBuf, unsigned char* const outBuf,
-	const unsigned char* const key, const size_t size);
-bool Crypto_CTRDecrypt(CryptoContext_s& ctx, const unsigned char* const inBuf, unsigned char* const outBuf,
-	const unsigned char* const key, const size_t size);
+bool Crypto_GenerateIV(CryptoContext_s& ctx, const u8* const data, const size_t size);
+
+bool Crypto_EncryptGCM(CryptoContext_s& ctx, const u8* const inBuf, u8* const outBuf,
+						const CryptoKey_t key,const size_t size,
+						const u8* const aad = nullptr, const size_t aadSize = 0);
+
+bool Crypto_DecryptGCM(CryptoContext_s& ctx, const u8* const inBuf, u8* const outBuf,
+						const CryptoKey_t key, const size_t size,
+						const u8* const aad = nullptr, const size_t aadSize = 0);
 
 #endif // TIER2_CRYPTUTILS_H

--- a/src/public/tier2/socketcreator.h
+++ b/src/public/tier2/socketcreator.h
@@ -8,20 +8,20 @@
 class CSocketCreator
 {
 public:
-	CSocketCreator(void);
+	CSocketCreator(const bool isServer);
 	~CSocketCreator(void);
 
 	void RunFrame(void);
 	void ProcessAccept(void);
 
-	bool CreateListenSocket(const netadr_t& netAdr, bool bDualStack = true);
+	bool CreateListenSocket(const netadr_t& netAdr, bool bDualStack = true, bool bReuse = false);
 	void CloseListenSocket(void);
 
 	int ConnectSocket(const netadr_t& netAdr, bool bSingleSocket);
 	void DisconnectSocket(SocketHandle_t hSocket);
 	void DisconnectSockets(void);
 
-	bool ConfigureSocket(SocketHandle_t hSocket, bool bDualStack = true);
+	bool ConfigureSocket(SocketHandle_t hSocket, bool bDualStack = true, bool bReuse = false);
 	int OnSocketAccepted(SocketHandle_t hSocket, const netadr_t& netAdr);
 
 	void CloseAcceptedSocket(int nIndex);
@@ -41,12 +41,6 @@ public:
 public:
 	struct AcceptedSocket_t
 	{
-		AcceptedSocket_t(SocketHandle_t hSocket)
-			: m_hSocket(hSocket)
-			, m_Data(hSocket)
-		{}
-
-		SocketHandle_t            m_hSocket;
 		netadr_t                  m_Address;
 		ConnectedNetConsoleData_s m_Data;
 	};
@@ -54,6 +48,7 @@ public:
 private:
 	CUtlVector<AcceptedSocket_t>  m_AcceptedSockets;
 	SocketHandle_t                m_hListenSocket; // Used to accept connections.
+	bool                          m_bIsServer;
 
 	enum
 	{

--- a/src/resource/protobuf/netcon.proto
+++ b/src/resource/protobuf/netcon.proto
@@ -48,9 +48,16 @@ message response
 // Message envelope
 //////////////////////////////////////////////////////////////////////
 
+message header
+{
+    uint64      seqNr     = 1;
+    uint64      sessionId = 2;
+}
+
 message envelope
 {
-    bool  encrypted = 1;
-    bytes nonce     = 2;
-    bytes data      = 3;
+    header header = 1;
+    bytes  iv     = 2;
+    bytes  tag    = 3;
+    bytes  data   = 4;
 }

--- a/src/tier1/NetAdr.cpp
+++ b/src/tier1/NetAdr.cpp
@@ -108,8 +108,10 @@ void CNetAdr::ToAdrinfo(addrinfo* pHint) const
 //////////////////////////////////////////////////////////////////////
 // Converts address to socket address.
 //////////////////////////////////////////////////////////////////////
-void CNetAdr::ToSockadr(struct sockaddr_storage* const pSadr) const
+void CNetAdr::ToSockadr(struct sockaddr_in6* const pSadr) const
 {
+	memset(pSadr, 0, sizeof(sockaddr_in6));
+
 	reinterpret_cast<sockaddr_in6*>(pSadr)->sin6_family = AF_INET6;
 	reinterpret_cast<sockaddr_in6*>(pSadr)->sin6_port = port;
 
@@ -126,19 +128,19 @@ void CNetAdr::ToSockadr(struct sockaddr_storage* const pSadr) const
 //////////////////////////////////////////////////////////////////////
 // Sets address from socket address.
 //////////////////////////////////////////////////////////////////////
-bool CNetAdr::SetFromSockadr(struct sockaddr_storage* const s)
+bool CNetAdr::SetFromSockadr(struct sockaddr_in6* const s)
 {
-	char szAdrv6[INET6_ADDRSTRLEN];
-	sockaddr_in6* pAdrv6 = reinterpret_cast<sockaddr_in6*>(s);
-
-	if (inet_ntop(pAdrv6->sin6_family, &pAdrv6->sin6_addr, szAdrv6, sizeof(szAdrv6)) &&
-		SetFromString(szAdrv6))
+	if (s->sin6_family != AF_INET6 && s->sin6_family != AF_INET)
 	{
-		SetPort(pAdrv6->sin6_port);
-		return true;
+		Clear();
+		return false;
 	}
 
-	return false;
+	SetType(netadrtype_t::NA_IP);
+	SetIP(&s->sin6_addr);
+	SetPort(s->sin6_port);
+
+	return true;
 }
 
 //////////////////////////////////////////////////////////////////////

--- a/src/tier2/cryptutils.cpp
+++ b/src/tier2/cryptutils.cpp
@@ -29,7 +29,7 @@ bool Plat_GenerateRandom(unsigned char* buffer, const uint32_t bufferSize, const
 	return true;
 }
 
-bool Crypto_GenerateIV(CryptoContext_s& ctx, const unsigned char* const data, const size_t size)
+bool Crypto_GenerateIV(CryptoContext_s& ctx, const u8* const data, const size_t size)
 {
 	mbedtls_entropy_context entropy;
 	mbedtls_entropy_init(&entropy);
@@ -39,14 +39,14 @@ bool Crypto_GenerateIV(CryptoContext_s& ctx, const unsigned char* const data, co
 
 	//mbedtls_ctr_drbg_seed will only accept a maximum of MBEDTLS_CTR_DRBG_MAX_SEED_INPUT - MBEDTLS_CTR_DRBG_ENTROPY_LEN as custom data for seed generation
 	//make sure to clamp the number of bytes we ask it to read
-	const size_t customDataLen = min(size, MBEDTLS_CTR_DRBG_MAX_SEED_INPUT - MBEDTLS_CTR_DRBG_ENTROPY_LEN);
+	const size_t customDataLen = Min<size_t>(size, MBEDTLS_CTR_DRBG_MAX_SEED_INPUT - MBEDTLS_CTR_DRBG_ENTROPY_LEN);
 
 	const int seedRet = mbedtls_ctr_drbg_seed(&drbg, mbedtls_entropy_func, &entropy, data, customDataLen);
 	int randRet = MBEDTLS_ERR_ERROR_GENERIC_ERROR;
 
 	if (seedRet == 0)
 	{
-		randRet = mbedtls_ctr_drbg_random(&drbg, ctx.ivData, sizeof(ctx.ivData));
+		randRet = mbedtls_ctr_drbg_random(&drbg, ctx.iv, sizeof(ctx.iv));
 	}
 
 	mbedtls_ctr_drbg_free(&drbg);
@@ -55,38 +55,65 @@ bool Crypto_GenerateIV(CryptoContext_s& ctx, const unsigned char* const data, co
 	return randRet == 0;
 }
 
-static bool Crypto_CTRCrypt(CryptoContext_s& ctx, const unsigned char* const inBuf,
-	unsigned char* const outBuf, const unsigned char* const key, const size_t size)
+bool Crypto_EncryptGCM(CryptoContext_s& ctx, const u8* const inBuf, u8* const outBuf,
+						const CryptoKey_t key, const size_t size,
+						const u8* const aad, const size_t aadSize)
 {
-	mbedtls_aes_context aes;
-	mbedtls_aes_init(&aes);
+	mbedtls_gcm_context gcm;
+	mbedtls_gcm_init(&gcm);
+
+	const int setRet =
+		mbedtls_gcm_setkey(&gcm, MBEDTLS_CIPHER_ID_AES, key, ctx.keyBits);
 
 	int cryptRet = MBEDTLS_ERR_ERROR_GENERIC_ERROR;
-	const int setRet = mbedtls_aes_setkey_enc(&aes, key, ctx.keyBits);
 
 	if (setRet == 0)
 	{
-		unsigned char nonceCounter[16];
-		unsigned char streamBlock[16];
-
-		size_t offset = 0;
-		memcpy(nonceCounter, ctx.ivData, sizeof(nonceCounter));
-
-		cryptRet = mbedtls_aes_crypt_ctr(&aes, size, &offset, nonceCounter, streamBlock, inBuf, outBuf);
+		cryptRet = mbedtls_gcm_crypt_and_tag(
+			&gcm,
+			MBEDTLS_GCM_ENCRYPT,
+			size,
+			ctx.iv,
+			sizeof(ctx.iv),
+			aad,
+			aadSize,
+			inBuf,
+			outBuf,
+			sizeof(CryptoTag_t),
+			ctx.tag);
 	}
 
-	mbedtls_aes_free(&aes);
+	mbedtls_gcm_free(&gcm);
 	return cryptRet == 0;
 }
 
-bool Crypto_CTREncrypt(CryptoContext_s& ctx, const unsigned char* const inBuf, unsigned char* const outBuf,
-	const unsigned char* const key, const size_t size)
+bool Crypto_DecryptGCM(CryptoContext_s& ctx, const u8* const inBuf, u8* const outBuf,
+						const CryptoKey_t key, const size_t size,
+						const u8* const aad, const size_t aadSize)
 {
-	return Crypto_CTRCrypt(ctx, inBuf, outBuf, key, size);
-}
+	mbedtls_gcm_context gcm;
+	mbedtls_gcm_init(&gcm);
 
-bool Crypto_CTRDecrypt(CryptoContext_s& ctx, const unsigned char* const inBuf, unsigned char* const outBuf,
-	const unsigned char* const key, const size_t size)
-{
-	return Crypto_CTRCrypt(ctx, inBuf, outBuf, key, size);
+	const int setRet =
+		mbedtls_gcm_setkey(&gcm, MBEDTLS_CIPHER_ID_AES, key, ctx.keyBits);
+
+	int cryptRet = MBEDTLS_ERR_ERROR_GENERIC_ERROR;
+
+	if (setRet == 0)
+	{
+		cryptRet = mbedtls_gcm_auth_decrypt(
+			&gcm,
+			size,
+			ctx.iv,
+			sizeof(ctx.iv),
+			aad,
+			aadSize,
+			ctx.tag,
+			sizeof(CryptoTag_t),
+			inBuf,
+			outBuf);
+	}
+
+	mbedtls_gcm_free(&gcm);
+	return cryptRet == 0;
 }

--- a/src/tier2/socketcreator.cpp
+++ b/src/tier2/socketcreator.cpp
@@ -91,7 +91,7 @@ bool CSocketCreator::CreateListenSocket(const netadr_t& netAdr, bool bDualStack,
 
 	if (m_hListenSocket != INVALID_SOCKET)
 	{
-		if (!ConfigureSocket(m_hListenSocket, bDualStack))
+		if (!ConfigureSocket(m_hListenSocket, bDualStack, bReuse))
 		{
 			CloseListenSocket();
 			return false;

--- a/src/tier2/socketcreator.cpp
+++ b/src/tier2/socketcreator.cpp
@@ -6,6 +6,7 @@
 
 #include <tier1/NetAdr.h>
 #include <tier2/socketcreator.h>
+#include <tier2/cryptutils.h>
 #ifndef _TOOLS
 #include <engine/sys_utils.h>
 #endif // !_TOOLS
@@ -14,9 +15,10 @@
 //-----------------------------------------------------------------------------
 // Purpose: Constructor
 //-----------------------------------------------------------------------------
-CSocketCreator::CSocketCreator(void)
+CSocketCreator::CSocketCreator(const bool isServer)
 {
 	m_hListenSocket = SOCKET_ERROR;
+	m_bIsServer = isServer;
 }
 
 //-----------------------------------------------------------------------------
@@ -43,7 +45,7 @@ void CSocketCreator::RunFrame(void)
 //-----------------------------------------------------------------------------
 void CSocketCreator::ProcessAccept(void)
 {
-	sockaddr_storage inClient{};
+	sockaddr_in6 inClient;
 	int nLengthAddr = sizeof(inClient);
 	const SocketHandle_t newSocket = SocketHandle_t(::accept(SOCKET(m_hListenSocket), reinterpret_cast<sockaddr*>(&inClient), &nLengthAddr));
 
@@ -79,9 +81,10 @@ void CSocketCreator::ProcessAccept(void)
 // Purpose: bind to a TCP port and accept incoming connections
 // Input  : *netAdr - 
 //			bDualStack - 
+//			bReuse - 
 // Output : true on success, failed otherwise
 //-----------------------------------------------------------------------------
-bool CSocketCreator::CreateListenSocket(const netadr_t& netAdr, bool bDualStack)
+bool CSocketCreator::CreateListenSocket(const netadr_t& netAdr, bool bDualStack, bool bReuse)
 {
 	CloseListenSocket();
 	m_hListenSocket = SocketHandle_t(::socket(PF_INET6, SOCK_STREAM, IPPROTO_TCP));
@@ -94,13 +97,13 @@ bool CSocketCreator::CreateListenSocket(const netadr_t& netAdr, bool bDualStack)
 			return false;
 		}
 
-		sockaddr_storage sadr{};
+		sockaddr_in6 sadr;
 		netAdr.ToSockadr(&sadr);
 
 		int results = ::bind(m_hListenSocket, reinterpret_cast<sockaddr*>(&sadr), sizeof(sockaddr_in6));
 		if (results == SOCKET_ERROR)
 		{
-			Warning(eDLL_T::COMMON, "Socket bind failed (%s)\n", NET_ErrorString(WSAGetLastError()));
+			Error(eDLL_T::COMMON, 0, "Socket bind failed (%s)\n", NET_ErrorString(WSAGetLastError()));
 			CloseListenSocket();
 
 			return false;
@@ -109,7 +112,7 @@ bool CSocketCreator::CreateListenSocket(const netadr_t& netAdr, bool bDualStack)
 		results = ::listen(m_hListenSocket, SOCKET_TCP_MAX_ACCEPTS);
 		if (results == SOCKET_ERROR)
 		{
-			Warning(eDLL_T::COMMON, "Socket listen failed (%s)\n", NET_ErrorString(WSAGetLastError()));
+			Error(eDLL_T::COMMON, 0, "Socket listen failed (%s)\n", NET_ErrorString(WSAGetLastError()));
 			CloseListenSocket();
 
 			return false;
@@ -146,7 +149,7 @@ int CSocketCreator::ConnectSocket(const netadr_t& netAdr, bool bSingleSocket)
 	SocketHandle_t hSocket = SocketHandle_t(::socket(AF_INET6, SOCK_STREAM, IPPROTO_TCP));
 	if (hSocket == SOCKET_ERROR)
 	{
-		Warning(eDLL_T::COMMON, "Unable to create socket (%s)\n", NET_ErrorString(WSAGetLastError()));
+		Error(eDLL_T::COMMON, 0, "Unable to create socket (%s)\n", NET_ErrorString(WSAGetLastError()));
 		return SOCKET_ERROR;
 	}
 
@@ -156,7 +159,7 @@ int CSocketCreator::ConnectSocket(const netadr_t& netAdr, bool bSingleSocket)
 		return SOCKET_ERROR;
 	}
 
-	struct sockaddr_storage s{};
+	struct sockaddr_in6 s;
 	netAdr.ToSockadr(&s);
 
 	const int results = ::connect(hSocket, reinterpret_cast<sockaddr*>(&s), sizeof(sockaddr_in6));
@@ -164,7 +167,7 @@ int CSocketCreator::ConnectSocket(const netadr_t& netAdr, bool bSingleSocket)
 	{
 		if (!IsSocketBlocking())
 		{
-			Warning(eDLL_T::COMMON, "Socket connection failed (%s)\n", NET_ErrorString(WSAGetLastError()));
+			Error(eDLL_T::COMMON, 0, "Socket connection failed (%s)\n", NET_ErrorString(WSAGetLastError()));
 
 			DisconnectSocket(hSocket);
 			return SOCKET_ERROR;
@@ -182,7 +185,7 @@ int CSocketCreator::ConnectSocket(const netadr_t& netAdr, bool bSingleSocket)
 
 		if (::select(hSocket + 1, NULL, &writefds, NULL, &tv) < 1) // block for at most 1 second.
 		{
-			Warning(eDLL_T::COMMON, "Socket connection timed out\n");
+			Error(eDLL_T::COMMON, 0, "Socket connection timed out\n");
 			DisconnectSocket(hSocket); // took too long to connect to, give up.
 
 			return SOCKET_ERROR;
@@ -218,26 +221,30 @@ void CSocketCreator::DisconnectSockets(void)
 // Purpose: Configures a socket for use
 // Input  : iSocket - 
 //			bDualStack - 
+//			bReuse - 
 // Output : true on success, false otherwise
 //-----------------------------------------------------------------------------
-bool CSocketCreator::ConfigureSocket(SocketHandle_t hSocket, bool bDualStack /*= true*/)
+bool CSocketCreator::ConfigureSocket(SocketHandle_t hSocket, bool bDualStack /*= true*/, bool bReuse /*= false*/)
 {
 	// Disable NAGLE as RCON cmds are small in size.
 	int opt = 1;
 	int ret = ::setsockopt(hSocket, IPPROTO_TCP, TCP_NODELAY, reinterpret_cast<char*>(&opt), sizeof(opt));
 	if (ret == SOCKET_ERROR)
 	{
-		Warning(eDLL_T::COMMON, "Socket 'sockopt(%s)' failed (%s)\n", "TCP_NODELAY", NET_ErrorString(WSAGetLastError()));
+		Error(eDLL_T::COMMON, 0, "Socket 'sockopt(%s)' failed (%s)\n", "TCP_NODELAY", NET_ErrorString(WSAGetLastError()));
 		return false;
 	}
 
-	// Mark socket as reusable.
-	opt = 1;
-	ret = ::setsockopt(hSocket, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<char*>(&opt), sizeof(opt));
-	if (ret == SOCKET_ERROR)
+	if (bReuse)
 	{
-		Warning(eDLL_T::COMMON, "Socket 'sockopt(%s)' failed (%s)\n", "SO_REUSEADDR", NET_ErrorString(WSAGetLastError()));
-		return false;
+		// Mark socket as reusable.
+		opt = 1;
+		ret = ::setsockopt(hSocket, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<char*>(&opt), sizeof(opt));
+		if (ret == SOCKET_ERROR)
+		{
+			Error(eDLL_T::COMMON, 0, "Socket 'sockopt(%s)' failed (%s)\n", "SO_REUSEADDR", NET_ErrorString(WSAGetLastError()));
+			return false;
+		}
 	}
 
 	if (bDualStack)
@@ -247,7 +254,7 @@ bool CSocketCreator::ConfigureSocket(SocketHandle_t hSocket, bool bDualStack /*=
 		ret = ::setsockopt(hSocket, IPPROTO_IPV6, IPV6_V6ONLY, reinterpret_cast<char*>(&opt), sizeof(opt));
 		if (ret == SOCKET_ERROR)
 		{
-			Warning(eDLL_T::COMMON, "Socket 'sockopt(%s)' failed (%s)\n", "IPV6_V6ONLY", NET_ErrorString(WSAGetLastError()));
+			Error(eDLL_T::COMMON, 0, "Socket 'sockopt(%s)' failed (%s)\n", "IPV6_V6ONLY", NET_ErrorString(WSAGetLastError()));
 			return false;
 		}
 	}
@@ -257,7 +264,7 @@ bool CSocketCreator::ConfigureSocket(SocketHandle_t hSocket, bool bDualStack /*=
 	ret = ::ioctlsocket(hSocket, FIONBIO, reinterpret_cast<u_long*>(&opt));
 	if (ret == SOCKET_ERROR)
 	{
-		Warning(eDLL_T::COMMON, "Socket 'ioctl(%s)' failed (%s)\n", "FIONBIO", NET_ErrorString(WSAGetLastError()));
+		Error(eDLL_T::COMMON, 0, "Socket 'ioctl(%s)' failed (%s)\n", "FIONBIO", NET_ErrorString(WSAGetLastError()));
 		return false;
 	}
 
@@ -272,10 +279,24 @@ bool CSocketCreator::ConfigureSocket(SocketHandle_t hSocket, bool bDualStack /*=
 //-----------------------------------------------------------------------------
 int CSocketCreator::OnSocketAccepted(SocketHandle_t hSocket, const netadr_t& netAdr)
 {
-	AcceptedSocket_t newEntry(hSocket);
-	newEntry.m_Address = netAdr;
+	const int hnd = m_AcceptedSockets.AddToTail();
+	AcceptedSocket_t& newEntry = m_AcceptedSockets[hnd];
 
-	return m_AcceptedSockets.AddToTail(newEntry);
+	newEntry.m_Address = netAdr;
+	newEntry.m_Data.socket = hSocket;
+	newEntry.m_Data.isServer = !m_bIsServer; // If we are the server, then this conn is a client.
+
+	const char* errorMsg;
+
+	if (!Plat_GenerateRandom((u8*)&newEntry.m_Data.sessionId, sizeof(newEntry.m_Data.sessionId), errorMsg))
+	{
+		Error(eDLL_T::COMMON, 0, "Error while generating session ID: [%s]\n", errorMsg);
+		m_AcceptedSockets.Remove(hnd);
+
+		return m_AcceptedSockets.InvalidIndex();
+	}
+
+	return hnd;
 }
 
 //-----------------------------------------------------------------------------
@@ -290,8 +311,10 @@ void CSocketCreator::CloseAcceptedSocket(int nIndex)
 		return;
 	}
 
-	AcceptedSocket_t& connected = m_AcceptedSockets[nIndex];
-	DisconnectSocket(connected.m_hSocket);
+	{
+		AcceptedSocket_t& connected = m_AcceptedSockets[nIndex];
+		DisconnectSocket(connected.m_Data.socket);
+	}
 
 	m_AcceptedSockets.Remove(nIndex);
 }
@@ -304,7 +327,7 @@ void CSocketCreator::CloseAllAcceptedSockets(void)
 	for (int i = 0; i < m_AcceptedSockets.Count(); ++i)
 	{
 		AcceptedSocket_t& connected = m_AcceptedSockets[i];
-		DisconnectSocket(connected.m_hSocket);
+		DisconnectSocket(connected.m_Data.socket);
 	}
 	m_AcceptedSockets.Purge();
 }
@@ -363,7 +386,7 @@ int CSocketCreator::GetAcceptedSocketCount(void) const
 SocketHandle_t CSocketCreator::GetAcceptedSocketHandle(int nIndex) const
 {
 	Assert(nIndex >= 0 && nIndex < m_AcceptedSockets.Count());
-	return m_AcceptedSockets[nIndex].m_hSocket;
+	return m_AcceptedSockets[nIndex].m_Data.socket;
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
- Encryption algorithm changed from AES-CTR to AES-GCM to authenticate new data
- Envelope sub-header contains session ID and sequence number (part of AAD to prevent replay attacks)
- Implemented port scanning with 64 tries to allow the system to bind to the first free port (scan starts from host_port)
- Implemented socket re-use when game is launched with -reuse (similar to the UDP socket)
- Fixed a bug inside CSocketCreator::CreateListenSocket() preventing socket reuse from working
- Fixed a bug inside CRConServer::Disconnect() preventing the listen socket from re-opening if all auth clients disconnect

This is a breaking change, all custom RCON clients must adapt to the new protocol. See `src/resource/protobuf/netcon.proto` for the new protocol and `src/netconsole/netconsole.cpp` for a reference implementation. Your client must also always send encrypted data if encryption is enabled, envelope.encrypted has been removed.